### PR TITLE
Switch CI to self-hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: []
     if: github.repository == 'fornewid/highlander'
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   update_draft_release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: github.repository == 'fornewid/highlander'
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   create-release-pr:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     # TODO: Replace permission check with `environment: release` after making repo public.
     # environment: release
     steps:


### PR DESCRIPTION
## Summary
- Switch `runs-on` from `ubuntu-latest` to `self-hosted` for all workflows
- Uses a self-hosted runner to eliminate GitHub Actions minutes consumption