### PR TITLE
Replace self-hosted runner with ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: []
     if: github.repository == 'fornewid/highlander'
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   update_draft_release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: github.repository == 'fornewid/highlander'
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   create-release-pr:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     # TODO: Replace permission check with `environment: release` after making repo public.
     # environment: release
     steps:


### PR DESCRIPTION
## Summary
- 모든 워크플로우의 `runs-on: self-hosted`를 `ubuntu-latest`로 변경

## Changed files
- `.github/workflows/build.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/release-drafter.yml`
- `.github/workflows/release.yml`