### PR TITLE
Prepare initial release version 0.0.1

### DIFF
--- a/highlander/gradle.properties
+++ b/highlander/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.fornewid.highlander
-VERSION_NAME=0.1.0-SNAPSHOT
+VERSION_NAME=0.0.1-SNAPSHOT
 
 POM_ARTIFACT_ID=highlander
 POM_NAME=Highlander


### PR DESCRIPTION
## Summary
- Set `VERSION_NAME` to `0.0.1-SNAPSHOT` for the first Maven Central release

## Next steps
After merging, run the **Create Release PR** workflow to publish `0.0.1`.