### PR TITLE
Add release-drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,6 @@
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: '$NEXT_PATCH_VERSION'
+template: |
+  ## What's Changed
+
+  $CHANGES


### PR DESCRIPTION
## Summary
- Add missing `.github/release-drafter.yml` that `release-drafter.yml` workflow requires
- Matches the same config used in manifest-shield