### PR TITLE
Prepare next development version 0.0.2-SNAPSHOT

### DIFF
--- a/highlander/gradle.properties
+++ b/highlander/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.fornewid.highlander
-VERSION_NAME=0.0.1
+VERSION_NAME=0.0.2-SNAPSHOT
 
 POM_ARTIFACT_ID=highlander
 POM_NAME=Highlander


### PR DESCRIPTION
## Summary
- Bump version to `0.0.2-SNAPSHOT` after `0.0.1` release