### PR TITLE
Fix configuration cache serialization for AGP variant captures

### DIFF
--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/Builder.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/Builder.kt
@@ -23,6 +23,6 @@ internal object Builder {
         // Do NOT use withPluginClasspath() - AGP classloader isolation issues.
         // Plugin JAR is injected via buildscript classpath in the test project.
         withProjectDir(project.dir)
-        withArguments(args.toList() + "-s")
+        withArguments(args.toList() + "-s" + "--configuration-cache" + "--configuration-cache-problems=fail")
     }
 }

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/AndroidVariantHandler.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/AndroidVariantHandler.kt
@@ -33,10 +33,15 @@ internal object AndroidVariantHandler {
         val declaredConfigNames = mutableSetOf<String>()
         val matchedConfigs = mutableSetOf<String>()
 
+        // Populate declared names unconditionally so validation still runs even
+        // if no variants are emitted (e.g. every variant disabled via beforeVariants).
+        extension.configurations.configureEach {
+            declaredConfigNames.add(configurationName)
+        }
+
         androidComponents.onVariants { variant ->
             allVariantNames.add(variant.name)
             extension.configurations.configureEach {
-                declaredConfigNames.add(configurationName)
                 if (configurationName == variant.name) {
                     matchedConfigs.add(configurationName)
                     registerTasks(project, extension.baselineDir.get(), this, variant, guardTask, baselineTask)

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/AndroidVariantHandler.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/AndroidVariantHandler.kt
@@ -29,37 +29,48 @@ internal object AndroidVariantHandler {
         val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
         verifyAgpVersion(androidComponents)
 
+        val allVariantNames = mutableSetOf<String>()
+        val declaredConfigNames = mutableSetOf<String>()
+        val matchedConfigs = mutableSetOf<String>()
+
         androidComponents.onVariants { variant ->
+            allVariantNames.add(variant.name)
             extension.configurations.configureEach {
+                declaredConfigNames.add(configurationName)
                 if (configurationName == variant.name) {
+                    matchedConfigs.add(configurationName)
                     registerTasks(project, extension.baselineDir.get(), this, variant, guardTask, baselineTask)
                 }
             }
         }
 
-        val validateConfigurations: () -> Unit = {
-            extension.configurations.forEach { config ->
-                val probeConfigName = "${config.configurationName}RuntimeClasspath"
-                if (project.configurations.findByName(probeConfigName) == null) {
-                    val availableVariants = project.configurations.names
-                        .filter { it.endsWith("RuntimeClasspath") }
-                        .map { it.removeSuffix("RuntimeClasspath") }
-                    throw GradleException(buildString {
-                        appendLine("Highlander could not resolve configuration \"${config.configurationName}\".")
-                        if (availableVariants.isNotEmpty()) {
-                            appendLine("Here are some valid configurations you could use.")
-                            appendLine()
-                            appendLine("highlander {")
-                            availableVariants.forEach { appendLine("    configuration(\"$it\")") }
-                            appendLine("}")
-                        }
-                    })
-                }
+        guardTask.configure {
+            validateConfigurations(declaredConfigNames, matchedConfigs, allVariantNames)
+        }
+        baselineTask.configure {
+            validateConfigurations(declaredConfigNames, matchedConfigs, allVariantNames)
+        }
+    }
+
+    private fun validateConfigurations(
+        declaredConfigNames: Set<String>,
+        matchedConfigs: Set<String>,
+        allVariantNames: Set<String>,
+    ) {
+        for (name in declaredConfigNames) {
+            if (name !in matchedConfigs) {
+                throw GradleException(buildString {
+                    appendLine("Highlander could not resolve configuration \"$name\".")
+                    if (allVariantNames.isNotEmpty()) {
+                        appendLine("Here are some valid configurations you could use.")
+                        appendLine()
+                        appendLine("highlander {")
+                        allVariantNames.forEach { appendLine("    configuration(\"$it\")") }
+                        appendLine("}")
+                    }
+                })
             }
         }
-
-        guardTask.configure { doFirst { validateConfigurations() } }
-        baselineTask.configure { doFirst { validateConfigurations() } }
     }
 
     private fun verifyAgpVersion(androidComponents: AndroidComponentsExtension<*, *, *>) {
@@ -137,6 +148,7 @@ internal object AndroidVariantHandler {
             task.scanAssets.set(config.assets)
             task.scanClasses.set(config.classes)
             task.baselineDir.set(baselineDirectory)
+            task.projectDir.set(project.layout.projectDirectory)
 
             // Configuration-cache-safe: convert ArtifactCollection to serializable map
             if (resArtifacts != null) {

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
@@ -44,6 +44,7 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
     @get:Input abstract val scanClasses: Property<Boolean>
 
     @get:Internal abstract val baselineDir: DirectoryProperty
+    @get:Internal abstract val projectDir: DirectoryProperty
 
     // @InputFiles ensures Gradle infers task dependencies (e.g., generateResValues).
     // @Optional allows scan types to be selectively disabled.
@@ -158,13 +159,13 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
 
         if (isBaseline) {
             file.writeText(currentContent)
-            val relPath = file.relativeTo(project.projectDir)
+            val relPath = file.relativeTo(projectDir.get().asFile)
             logger.lifecycle("Highlander baseline created: $relPath")
             return null
         }
 
         if (!file.exists()) {
-            val relPath = file.relativeTo(project.projectDir)
+            val relPath = file.relativeTo(projectDir.get().asFile)
             return buildString {
                 appendLine("=== $label ===")
                 appendLine("Baseline not found: $relPath")


### PR DESCRIPTION
## Summary

- Collect validation data as plain `Set<String>` during `onVariants`/`configureEach` and validate at task configuration time, removing the `doFirst` that captured `extension`/`project`. This breaks the CC chain `task → extension → configurations container → Variant → KotlinCompilationImpl.compileDependencyFiles`, which was also surfacing as the `debugCompileClasspath` variant-matching ambiguity under AGP 9.1 / Gradle 9.3.
- Replace `project.projectDir` in `HighlanderCheckTask` with an injected `DirectoryProperty` to eliminate the remaining `Task.project` usage at execution time.
- Enable `--configuration-cache --configuration-cache-problems=fail` in the gradleTest `Builder` fixture so all plugin tests exercise CC strictly and future regressions fail loudly.

Fixes #15

## Test plan

- [x] `:highlander:test`
- [x] `:highlander:gradleTest` (runs with `--configuration-cache --configuration-cache-problems=fail`)
- [x] `:sample:app:highlanderBaselineRelease --configuration-cache` → "Configuration cache entry stored"
- [x] `:sample:app:highlanderRelease --configuration-cache` (2nd run) → "Configuration cache entry reused"

## Follow-up

- #16 — add flavored-variant coverage to gradleTest