### PR TITLE
Skip empty-body <item type="id"/> duplicates in values scanner

### DIFF
--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ValuesResourceScanner.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ValuesResourceScanner.kt
@@ -95,6 +95,11 @@ internal object ValuesResourceScanner {
                 val name = (node as? org.w3c.dom.Element)?.getAttribute("name")
                 if (name.isNullOrBlank()) continue
 
+                // AAPT2 treats <item type="id" name=".."/> with empty body as a weak Id value
+                // that merges across declarations without error (same R.id.* int), so duplicates
+                // are not a real conflict.
+                if (tagName == "item" && resType == "id" && isEmptyBody(node)) continue
+
                 // Key: "values-qualifier/type/name" e.g., "values/string/app_name"
                 val key = "$qualifier/$resType/$name"
                 entryMap.getOrPut(key) { mutableSetOf() }.add(source)
@@ -106,6 +111,26 @@ internal object ValuesResourceScanner {
         } catch (_: javax.xml.parsers.ParserConfigurationException) {
             // Skip if parser cannot be configured
         }
+    }
+
+    private fun isEmptyBody(node: org.w3c.dom.Node): Boolean {
+        val children = node.childNodes
+        for (i in 0 until children.length) {
+            val child = children.item(i)
+            when (child.nodeType) {
+                org.w3c.dom.Node.ELEMENT_NODE -> return false
+                org.w3c.dom.Node.TEXT_NODE,
+                org.w3c.dom.Node.CDATA_SECTION_NODE -> {
+                    if (!child.nodeValue.isNullOrBlank()) return false
+                }
+                org.w3c.dom.Node.COMMENT_NODE,
+                org.w3c.dom.Node.PROCESSING_INSTRUCTION_NODE -> continue
+                // Conservative: unfamiliar node types (e.g. ENTITY_REFERENCE) may carry text
+                // that AAPT2 would see as non-empty body; treat as non-empty to avoid false skips.
+                else -> return false
+            }
+        }
+        return true
     }
 
     private fun resolveResourceType(tagName: String, node: org.w3c.dom.Node): String? {

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ValuesResourceScanner.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ValuesResourceScanner.kt
@@ -95,10 +95,10 @@ internal object ValuesResourceScanner {
                 val name = (node as? org.w3c.dom.Element)?.getAttribute("name")
                 if (name.isNullOrBlank()) continue
 
-                // AAPT2 treats <item type="id" name=".."/> with empty body as a weak Id value
-                // that merges across declarations without error (same R.id.* int), so duplicates
-                // are not a real conflict.
-                if (tagName == "item" && resType == "id" && isEmptyBody(node)) continue
+                // AAPT2 treats empty-body id declarations (<item type="id" name=".."/> or the
+                // shorthand <id name=".."/>) as weak Id values that merge across declarations
+                // without error (same R.id.* int), so duplicates are not a real conflict.
+                if (resType == "id" && isEmptyBody(node)) continue
 
                 // Key: "values-qualifier/type/name" e.g., "values/string/app_name"
                 val key = "$qualifier/$resType/$name"

--- a/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ValuesResourceScannerTest.kt
+++ b/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ValuesResourceScannerTest.kt
@@ -84,7 +84,7 @@ internal class ValuesResourceScannerTest {
     }
 
     @Test
-    fun `handles item tags with type attribute`() {
+    fun `empty body id item is treated as weak slot and skipped`() {
         val moduleA = createResDir("moduleA", mapOf(
             "values/ids.xml" to """
                 <resources><item type="id" name="my_id"/></resources>
@@ -101,8 +101,116 @@ internal class ValuesResourceScannerTest {
             moduleB to SourceOrigin.Module(":b"),
         ))
 
+        // AAPT2 merges weak Id values without error, so this is not a real conflict.
+        assertThat(duplicates).isEmpty()
+    }
+
+    @Test
+    fun `id item with reference body is still tracked as duplicate`() {
+        val moduleA = createResDir("moduleA", mapOf(
+            "values/ids.xml" to """
+                <resources><item type="id" name="aliased">@id/other</item></resources>
+            """.trimIndent(),
+        ))
+        val moduleB = createResDir("moduleB", mapOf(
+            "values/ids.xml" to """
+                <resources><item type="id" name="aliased">@id/different</item></resources>
+            """.trimIndent(),
+        ))
+
+        val duplicates = ValuesResourceScanner.scan(listOf(
+            moduleA to SourceOrigin.Module(":a"),
+            moduleB to SourceOrigin.Module(":b"),
+        ))
+
+        assertThat(duplicates).hasSize(1)
+        assertThat(duplicates[0].resourceKey).isEqualTo("values/id/aliased")
+    }
+
+    @Test
+    fun `whitespace-only id item is treated as empty body`() {
+        val moduleA = createResDir("moduleA", mapOf(
+            "values/ids.xml" to """
+                <resources><item type="id" name="my_id">   </item></resources>
+            """.trimIndent(),
+        ))
+        val moduleB = createResDir("moduleB", mapOf(
+            "values/ids.xml" to """
+                <resources><item type="id" name="my_id"></item></resources>
+            """.trimIndent(),
+        ))
+
+        val duplicates = ValuesResourceScanner.scan(listOf(
+            moduleA to SourceOrigin.Module(":a"),
+            moduleB to SourceOrigin.Module(":b"),
+        ))
+
+        assertThat(duplicates).isEmpty()
+    }
+
+    @Test
+    fun `comment-only id item body is treated as empty`() {
+        val moduleA = createResDir("moduleA", mapOf(
+            "values/ids.xml" to """
+                <resources><item type="id" name="my_id"><!-- reserved --></item></resources>
+            """.trimIndent(),
+        ))
+        val moduleB = createResDir("moduleB", mapOf(
+            "values/ids.xml" to """
+                <resources><item type="id" name="my_id"/></resources>
+            """.trimIndent(),
+        ))
+
+        val duplicates = ValuesResourceScanner.scan(listOf(
+            moduleA to SourceOrigin.Module(":a"),
+            moduleB to SourceOrigin.Module(":b"),
+        ))
+
+        assertThat(duplicates).isEmpty()
+    }
+
+    @Test
+    fun `id item with comment plus non-blank text is tracked as duplicate`() {
+        val moduleA = createResDir("moduleA", mapOf(
+            "values/ids.xml" to """
+                <resources><item type="id" name="my_id">  <!-- note -->@id/other</item></resources>
+            """.trimIndent(),
+        ))
+        val moduleB = createResDir("moduleB", mapOf(
+            "values/ids.xml" to """
+                <resources><item type="id" name="my_id">@id/different</item></resources>
+            """.trimIndent(),
+        ))
+
+        val duplicates = ValuesResourceScanner.scan(listOf(
+            moduleA to SourceOrigin.Module(":a"),
+            moduleB to SourceOrigin.Module(":b"),
+        ))
+
         assertThat(duplicates).hasSize(1)
         assertThat(duplicates[0].resourceKey).isEqualTo("values/id/my_id")
+    }
+
+    @Test
+    fun `non-id item tags with empty body are still tracked`() {
+        val moduleA = createResDir("moduleA", mapOf(
+            "values/items.xml" to """
+                <resources><item type="string" name="empty_str"/></resources>
+            """.trimIndent(),
+        ))
+        val moduleB = createResDir("moduleB", mapOf(
+            "values/items.xml" to """
+                <resources><item type="string" name="empty_str"/></resources>
+            """.trimIndent(),
+        ))
+
+        val duplicates = ValuesResourceScanner.scan(listOf(
+            moduleA to SourceOrigin.Module(":a"),
+            moduleB to SourceOrigin.Module(":b"),
+        ))
+
+        assertThat(duplicates).hasSize(1)
+        assertThat(duplicates[0].resourceKey).isEqualTo("values/string/empty_str")
     }
 
     @Test

--- a/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ValuesResourceScannerTest.kt
+++ b/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ValuesResourceScannerTest.kt
@@ -106,6 +106,27 @@ internal class ValuesResourceScannerTest {
     }
 
     @Test
+    fun `empty body id shorthand tag is also skipped`() {
+        val moduleA = createResDir("moduleA", mapOf(
+            "values/ids.xml" to """
+                <resources><id name="shared"/></resources>
+            """.trimIndent(),
+        ))
+        val moduleB = createResDir("moduleB", mapOf(
+            "values/ids.xml" to """
+                <resources><item type="id" name="shared"/></resources>
+            """.trimIndent(),
+        ))
+
+        val duplicates = ValuesResourceScanner.scan(listOf(
+            moduleA to SourceOrigin.Module(":a"),
+            moduleB to SourceOrigin.Module(":b"),
+        ))
+
+        assertThat(duplicates).isEmpty()
+    }
+
+    @Test
     fun `id item with reference body is still tracked as duplicate`() {
         val moduleA = createResDir("moduleA", mapOf(
             "values/ids.xml" to """


### PR DESCRIPTION
## Summary

AAPT2 treats empty-body `<item type="id" name="..."/>` as a weak `Id` value (see `Id()` ctor setting `weak_ = true` in AOSP `ResourceValues.h`), so duplicate declarations across libraries merge into a single `R.id.*` without error. Reporting them as duplicates in Highlander produces dozens of `# conflict` entries (e.g. `accessibility_custom_action_N` shared between `androidx.core:core` and `androidx.compose.ui:ui-android`) that desensitize developers to real conflicts.

This PR excludes empty-body id items from the values-resources scan:

- `ValuesResourceScanner.parseValuesXml` skips entries where `tagName == "item" && resType == "id" && isEmptyBody(node)`.
- `isEmptyBody` inspects child nodes: Element children → non-empty; blank Text/CDATA → ignored; Comment/ProcessingInstruction → ignored; unknown node types → conservatively treated as non-empty.
- Id items with a reference body (e.g. `@id/bar`) are still tracked — that form is not guaranteed to be weak.

Fixes #19

## Test plan

- [x] `:highlander:test` (new unit tests cover empty body, reference body, whitespace-only, comment-only, comment+text, non-id empty body)
- [x] `:highlander:gradleTest` (CC strict mode)

## Migration note

Existing baselines that contained `<item type="id"/>` entries will show them as "removed" on the next guard run. Re-baseline once: `./gradlew :<project>:highlanderBaseline<Variant>`.