### PR TITLE
Add excludeAndroidXValues flag to filter AndroidX from values scan

### DIFF
--- a/highlander/api/highlander.api
+++ b/highlander/api/highlander.api
@@ -3,12 +3,14 @@ public class io/github/fornewid/gradle/plugins/highlander/HighlanderConfiguratio
 	public final fun getAssets ()Z
 	public final fun getClasses ()Z
 	public final fun getConfigurationName ()Ljava/lang/String;
+	public final fun getExcludeAndroidXValues ()Z
 	public fun getName ()Ljava/lang/String;
 	public final fun getNativeLibs ()Z
 	public final fun getResources ()Z
 	public final fun getValuesResources ()Z
 	public final fun setAssets (Z)V
 	public final fun setClasses (Z)V
+	public final fun setExcludeAndroidXValues (Z)V
 	public final fun setNativeLibs (Z)V
 	public final fun setResources (Z)V
 	public final fun setValuesResources (Z)V

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
@@ -2,6 +2,8 @@ package io.github.fornewid.gradle.plugins.highlander
 
 import com.google.common.truth.Truth.assertThat
 import io.github.fornewid.gradle.plugins.highlander.fixture.AndroidProject
+import io.github.fornewid.gradle.plugins.highlander.fixture.AndroidXValuesProject
+import io.github.fornewid.gradle.plugins.highlander.fixture.Builder
 import io.github.fornewid.gradle.plugins.highlander.fixture.Builder.build
 import io.github.fornewid.gradle.plugins.highlander.fixture.Builder.buildAndFail
 import org.junit.jupiter.api.Test
@@ -79,6 +81,30 @@ internal class HighlanderPluginTest {
             assertThat(result.output).contains("could not resolve configuration \"nonExistent\"")
             assertThat(result.output).contains("configuration(\"release\")")
             assertThat(result.output).contains("configuration(\"debug\")")
+        }
+    }
+
+    @Test
+    fun `excludeAndroidXValues true filters androidx values duplicates from baseline`() {
+        AndroidXValuesProject(excludeAndroidXValues = true).use { project ->
+            Builder.build(project.dir, ":app:highlanderBaselineRelease")
+
+            val baseline = project.readFile("app/highlander/releaseValues.txt")
+            // AndroidX group filtered out → no duplicate reported; file is created but empty.
+            assertThat(baseline).isEqualTo("")
+        }
+    }
+
+    @Test
+    fun `excludeAndroidXValues false keeps androidx values duplicates in baseline`() {
+        AndroidXValuesProject(excludeAndroidXValues = false).use { project ->
+            Builder.build(project.dir, ":app:highlanderBaselineRelease")
+
+            val baseline = project.readFile("app/highlander/releaseValues.txt")
+            assertThat(baseline).isNotNull()
+            assertThat(baseline).contains("values/string/shared_string")
+            assertThat(baseline).contains("androidx.testsample:fake:1.0.0")
+            assertThat(baseline).contains(":app")
         }
     }
 

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidXValuesProject.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidXValuesProject.kt
@@ -1,0 +1,203 @@
+package io.github.fornewid.gradle.plugins.highlander.fixture
+
+import java.io.File
+import java.io.ByteArrayOutputStream
+import java.util.UUID
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * A gradleTest fixture that publishes a synthetic AAR under the `androidx.testsample` group
+ * to a project-local maven repo. Used to exercise AndroidX-specific filtering paths without
+ * depending on a live AndroidX release.
+ */
+internal class AndroidXValuesProject(
+    private val excludeAndroidXValues: Boolean,
+) : AutoCloseable {
+
+    val dir: File = File("build/gradleTest/${UUID.randomUUID()}").apply { mkdirs() }
+
+    init {
+        val pluginJar = System.getProperty("pluginJar")
+            ?: error("pluginJar system property not set. Run via '../gradlew gradleTest'")
+        val escapedJar = pluginJar.replace("\\", "/")
+
+        val localRepo = dir.resolve("local-maven-repo").apply { mkdirs() }
+        publishFakeAndroidXAar(localRepo)
+        val escapedRepo = localRepo.absolutePath.replace("\\", "/")
+
+        dir.resolve("settings.gradle").writeText(
+            """
+            rootProject.name = "test-project"
+            include ':app'
+            """.trimIndent()
+        )
+
+        dir.resolve("build.gradle").writeText(
+            """
+            buildscript {
+                repositories {
+                    google()
+                    mavenCentral()
+                    maven { url '$escapedRepo' }
+                }
+                dependencies {
+                    classpath 'com.android.tools.build:gradle:8.5.0'
+                    classpath files('$escapedJar')
+                }
+            }
+            allprojects {
+                repositories {
+                    google()
+                    mavenCentral()
+                    maven { url '$escapedRepo' }
+                }
+            }
+            """.trimIndent()
+        )
+
+        dir.resolve("gradle.properties").writeText(
+            """
+            android.useAndroidX=true
+            org.gradle.jvmargs=-Xmx1g
+            """.trimIndent()
+        )
+
+        val androidHome = System.getenv("ANDROID_HOME")
+            ?: System.getenv("ANDROID_SDK_ROOT")
+            ?: findSdkDirFromLocalProperties()
+            ?: error("ANDROID_HOME or ANDROID_SDK_ROOT must be set")
+        dir.resolve("local.properties").writeText("sdk.dir=$androidHome")
+
+        val appDir = dir.resolve("app").apply { mkdirs() }
+        appDir.resolve("build.gradle").writeText(
+            """
+            apply plugin: 'com.android.application'
+            apply plugin: 'io.github.fornewid.highlander'
+
+            android {
+                compileSdk 34
+                namespace "io.github.fornewid.test.app"
+                defaultConfig {
+                    minSdk 23
+                    targetSdk 34
+                }
+            }
+
+            dependencies {
+                implementation 'androidx.testsample:fake:1.0.0'
+            }
+
+            highlander {
+                configuration("release") {
+                    resources = false
+                    valuesResources = true
+                    nativeLibs = false
+                    assets = false
+                    classes = false
+                    excludeAndroidXValues = $excludeAndroidXValues
+                }
+            }
+            """.trimIndent()
+        )
+
+        val appSrcDir = appDir.resolve("src/main").apply { mkdirs() }
+        appSrcDir.resolve("AndroidManifest.xml").writeText(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <application>
+                    <activity android:name=".MainActivity" android:exported="true" />
+                </application>
+            </manifest>
+            """.trimIndent()
+        )
+
+        val appStrings = appSrcDir.resolve("res/values/strings.xml")
+        appStrings.parentFile.mkdirs()
+        appStrings.writeText(
+            """
+            <resources>
+                <string name="shared_string">from-app</string>
+            </resources>
+            """.trimIndent()
+        )
+    }
+
+    fun readFile(relativePath: String): String? {
+        val file = dir.resolve(relativePath)
+        return if (file.exists()) file.readText() else null
+    }
+
+    override fun close() {
+        dir.deleteRecursively()
+    }
+
+    private fun publishFakeAndroidXAar(repoDir: File) {
+        val group = "androidx/testsample"
+        val artifact = "fake"
+        val version = "1.0.0"
+        val artifactDir = repoDir.resolve("$group/$artifact/$version").apply { mkdirs() }
+
+        val aarFile = artifactDir.resolve("$artifact-$version.aar")
+        ZipOutputStream(aarFile.outputStream()).use { zip ->
+            zip.putNextEntry(ZipEntry("AndroidManifest.xml"))
+            zip.write(
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                    package="androidx.testsample.fake" />
+                """.trimIndent().toByteArray()
+            )
+            zip.closeEntry()
+
+            zip.putNextEntry(ZipEntry("R.txt"))
+            zip.closeEntry()
+
+            val emptyJar = ByteArrayOutputStream().apply {
+                ZipOutputStream(this).close()
+            }.toByteArray()
+            zip.putNextEntry(ZipEntry("classes.jar"))
+            zip.write(emptyJar)
+            zip.closeEntry()
+
+            zip.putNextEntry(ZipEntry("res/values/strings.xml"))
+            zip.write(
+                """
+                <resources>
+                    <string name="shared_string">from-androidx</string>
+                </resources>
+                """.trimIndent().toByteArray()
+            )
+            zip.closeEntry()
+        }
+
+        val pomFile = artifactDir.resolve("$artifact-$version.pom")
+        pomFile.writeText(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>androidx.testsample</groupId>
+                <artifactId>fake</artifactId>
+                <version>1.0.0</version>
+                <packaging>aar</packaging>
+            </project>
+            """.trimIndent()
+        )
+    }
+
+    private fun findSdkDirFromLocalProperties(): String? {
+        var current: File? = File("").absoluteFile
+        while (current != null) {
+            val localProps = current.resolve("local.properties")
+            if (localProps.exists()) {
+                val props = java.util.Properties().apply { localProps.reader().use { load(it) } }
+                val sdkDir = props.getProperty("sdk.dir")
+                if (sdkDir != null) return sdkDir
+            }
+            current = current.parentFile
+        }
+        return null
+    }
+}

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/Builder.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/Builder.kt
@@ -2,27 +2,28 @@ package io.github.fornewid.gradle.plugins.highlander.fixture
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import java.io.File
 
 internal object Builder {
 
-    fun build(
-        project: AndroidProject,
-        vararg args: String,
-    ): BuildResult = runner(project, *args).build()
+    fun build(project: AndroidProject, vararg args: String): BuildResult =
+        build(project.dir, *args)
 
-    fun buildAndFail(
-        project: AndroidProject,
-        vararg args: String,
-    ): BuildResult = runner(project, *args).buildAndFail()
+    fun buildAndFail(project: AndroidProject, vararg args: String): BuildResult =
+        buildAndFail(project.dir, *args)
 
-    private fun runner(
-        project: AndroidProject,
-        vararg args: String,
-    ): GradleRunner = GradleRunner.create().apply {
-        forwardOutput()
-        // Do NOT use withPluginClasspath() - AGP classloader isolation issues.
-        // Plugin JAR is injected via buildscript classpath in the test project.
-        withProjectDir(project.dir)
-        withArguments(args.toList() + "-s" + "--configuration-cache" + "--configuration-cache-problems=fail")
-    }
+    fun build(dir: File, vararg args: String): BuildResult =
+        runner(dir, *args).build()
+
+    fun buildAndFail(dir: File, vararg args: String): BuildResult =
+        runner(dir, *args).buildAndFail()
+
+    private fun runner(dir: File, vararg args: String): GradleRunner =
+        GradleRunner.create().apply {
+            forwardOutput()
+            // Do NOT use withPluginClasspath() - AGP classloader isolation issues.
+            // Plugin JAR is injected via buildscript classpath in the test project.
+            withProjectDir(dir)
+            withArguments(args.toList() + "-s" + "--configuration-cache" + "--configuration-cache-problems=fail")
+        }
 }

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderConfiguration.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderConfiguration.kt
@@ -18,6 +18,25 @@ public open class HighlanderConfiguration @Inject constructor(
     /** Scan for duplicate values resources (strings, colors, etc.) */
     public var valuesResources: Boolean = false
 
+    /**
+     * Skip AndroidX libraries (group prefix `androidx.`) when reporting values-resource
+     * duplicates. Enabled by default: AndroidX components (Compose, Core, etc.) routinely
+     * share benign resource declarations by design, and most duplicates they produce are
+     * not actionable. Disable to see the full set.
+     *
+     * Only affects the values-resources scan. Other scans (`resources`, `nativeLibs`,
+     * `assets`, `classes`) are unaffected.
+     *
+     * Semantics: the filter drops AndroidX sources from the scan input before looking
+     * for duplicates. If an AndroidX library declares the same name as your app or
+     * another library, the AndroidX side is discarded and the remaining sources are
+     * compared among themselves. A key touched by AndroidX + exactly one non-AndroidX
+     * source therefore disappears from the report entirely.
+     *
+     * Has no effect unless [valuesResources] is also true.
+     */
+    public var excludeAndroidXValues: Boolean = true
+
     /** Scan for duplicate native libraries (.so) */
     public var nativeLibs: Boolean = false
 

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/AndroidVariantHandler.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/AndroidVariantHandler.kt
@@ -152,6 +152,7 @@ internal object AndroidVariantHandler {
             task.scanNativeLibs.set(config.nativeLibs)
             task.scanAssets.set(config.assets)
             task.scanClasses.set(config.classes)
+            task.excludeAndroidXValues.set(config.excludeAndroidXValues)
             task.baselineDir.set(baselineDirectory)
             task.projectDir.set(project.layout.projectDirectory)
 

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
@@ -213,17 +213,15 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
         val sources = mutableListOf<Pair<File, SourceOrigin>>()
         sources.addAll(resolveFromMapping(resArtifactMapping))
         addLocalDirs(sources, localResourceDirs)
-        val effective = if (excludeAndroidXValues.get()) {
-            sources.filterNot { (_, origin) -> isAndroidXDependency(origin) }
-        } else {
-            sources
+        if (excludeAndroidXValues.get()) {
+            sources.removeAll { (_, origin) -> isAndroidXDependency(origin) }
         }
-        return ValuesResourceScanner.scan(effective)
+        return ValuesResourceScanner.scan(sources)
     }
 
     private fun isAndroidXDependency(origin: SourceOrigin): Boolean {
         return origin is SourceOrigin.ExternalDependency &&
-            origin.coordinates.startsWith("androidx.")
+            origin.displayName.startsWith("androidx.")
     }
 
     private fun scanJni(): List<DuplicateEntry> {

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
@@ -42,6 +42,7 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
     @get:Input abstract val scanNativeLibs: Property<Boolean>
     @get:Input abstract val scanAssets: Property<Boolean>
     @get:Input abstract val scanClasses: Property<Boolean>
+    @get:Input abstract val excludeAndroidXValues: Property<Boolean>
 
     @get:Internal abstract val baselineDir: DirectoryProperty
     @get:Internal abstract val projectDir: DirectoryProperty
@@ -212,7 +213,17 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
         val sources = mutableListOf<Pair<File, SourceOrigin>>()
         sources.addAll(resolveFromMapping(resArtifactMapping))
         addLocalDirs(sources, localResourceDirs)
-        return ValuesResourceScanner.scan(sources)
+        val effective = if (excludeAndroidXValues.get()) {
+            sources.filterNot { (_, origin) -> isAndroidXDependency(origin) }
+        } else {
+            sources
+        }
+        return ValuesResourceScanner.scan(effective)
+    }
+
+    private fun isAndroidXDependency(origin: SourceOrigin): Boolean {
+        return origin is SourceOrigin.ExternalDependency &&
+            origin.coordinates.startsWith("androidx.")
     }
 
     private fun scanJni(): List<DuplicateEntry> {


### PR DESCRIPTION
## Summary

Adds a boolean flag `excludeAndroidXValues` to `HighlanderConfiguration`, defaulting to **true**. When enabled, the values-resources scan drops sources whose Gradle coordinates start with `androidx.` before looking for duplicates. AndroidX components (Compose, Core, etc.) share benign value declarations by design, so most duplicates they produce are non-actionable.

Scope is intentionally narrow:
- Only `scanValues()` is affected. `resources`, `assets`, `nativeLibs`, `classes` are unchanged.
- Only `ModuleComponentIdentifier` sources (external dependencies) with `androidx.` group prefix are matched. Local project modules always pass through.
- Has no effect when `valuesResources = false` (no-op).

Fixes #20

## Migration note (behavior change)

**Default is `true`.** Users who enabled `valuesResources = true` on a previous release and baselined entries sourced from AndroidX will see those entries disappear on the first run after upgrading:

- Run `./gradlew :<project>:highlanderBaseline<Variant>` once to refresh.
- Set `excludeAndroidXValues = false` under the configuration block to preserve prior behavior.

Rationale for default=true: the primary signal value of this scan is catching third-party SDK duplicates, which AndroidX entries drown out. Opt-in would leave new users with a noisy baseline out of the box.

## Semantics note

The filter drops AndroidX **sources** from the scan input, not final duplicate entries. If a key is declared by AndroidX + exactly one other source, the other source becomes the only remaining declaration and the key is no longer a "duplicate" — it disappears from the report. This is intentional per the issue but worth calling out. See extended KDoc in `HighlanderConfiguration.kt`.

## Test plan

- [x] `:highlander:test`
- [x] `:highlander:gradleTest` (CC strict mode)
- [x] New `AndroidXValuesProject` fixture publishes a synthetic `androidx.testsample:fake:1.0.0` AAR to a project-local maven repo; two gradleTest cases cover flag=true (baseline empty) and flag=false (baseline contains the AndroidX-declared duplicate).

## Follow-up

- #22 — extract shared TestProjectScaffold from gradleTest fixtures (fixture duplication)
- #23 — consider naming/grouping for future `excludeAndroidX*` flags (API design)