### PR TITLE
Extract shared TestProjectScaffold for gradleTest fixtures

### DIFF
--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidProject.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidProject.kt
@@ -1,7 +1,6 @@
 package io.github.fornewid.gradle.plugins.highlander.fixture
 
 import java.io.File
-import java.util.UUID
 
 internal class AndroidProject(
     private val pluginConfig: String = DEFAULT_PLUGIN_CONFIG,
@@ -9,58 +8,15 @@ internal class AndroidProject(
     private val moduleResources: Map<String, String> = emptyMap(),
 ) : AutoCloseable {
 
-    val dir: File = File("build/gradleTest/${UUID.randomUUID()}").apply { mkdirs() }
+    private val scaffold: TestProjectScaffold = TestProjectScaffold.create()
+
+    val dir: File get() = scaffold.dir
 
     init {
-        val pluginJar = System.getProperty("pluginJar")
-            ?: error("pluginJar system property not set. Run via '../gradlew gradleTest'")
-        val escapedJar = pluginJar.replace("\\", "/")
-
-        // settings.gradle
-        dir.resolve("settings.gradle").writeText(
-            """
-            rootProject.name = "test-project"
-            include ':app'
-            include ':module1'
-            """.trimIndent()
-        )
-
-        // root build.gradle
-        dir.resolve("build.gradle").writeText(
-            """
-            buildscript {
-                repositories {
-                    google()
-                    mavenCentral()
-                }
-                dependencies {
-                    classpath 'com.android.tools.build:gradle:8.5.0'
-                    classpath files('$escapedJar')
-                }
-            }
-            allprojects {
-                repositories {
-                    google()
-                    mavenCentral()
-                }
-            }
-            """.trimIndent()
-        )
-
-        // gradle.properties
-        dir.resolve("gradle.properties").writeText(
-            """
-            android.useAndroidX=true
-            org.gradle.jvmargs=-Xmx1g
-            """.trimIndent()
-        )
-
-        // local.properties
-        val androidHome = System.getenv("ANDROID_HOME")
-            ?: System.getenv("ANDROID_SDK_ROOT")
-            ?: findSdkDirFromLocalProperties()
-            ?: error("ANDROID_HOME or ANDROID_SDK_ROOT must be set")
-        dir.resolve("local.properties").writeText("sdk.dir=$androidHome")
+        scaffold.writeSettings("test-project", listOf(":app", ":module1"))
+        scaffold.writeRootBuildscript()
+        scaffold.writeGradleProperties()
+        scaffold.writeLocalProperties()
 
         // app module
         val appDir = dir.resolve("app").apply { mkdirs() }
@@ -98,7 +54,6 @@ internal class AndroidProject(
             """.trimIndent()
         )
 
-        // Create app resources
         for ((path, content) in appResources) {
             val file = appSrcDir.resolve("res/$path")
             file.parentFile.mkdirs()
@@ -122,14 +77,8 @@ internal class AndroidProject(
         )
 
         val module1SrcDir = module1Dir.resolve("src/main").apply { mkdirs() }
-        module1SrcDir.resolve("AndroidManifest.xml").writeText(
-            """
-            <?xml version="1.0" encoding="utf-8"?>
-            <manifest xmlns:android="http://schemas.android.com/apk/res/android" />
-            """.trimIndent()
-        )
+        scaffold.writeEmptyManifest(module1SrcDir.resolve("AndroidManifest.xml"))
 
-        // Create module1 resources
         for ((path, content) in moduleResources) {
             val file = module1SrcDir.resolve("res/$path")
             file.parentFile.mkdirs()
@@ -137,10 +86,7 @@ internal class AndroidProject(
         }
     }
 
-    fun readFile(relativePath: String): String? {
-        val file = dir.resolve(relativePath)
-        return if (file.exists()) file.readText() else null
-    }
+    fun readFile(relativePath: String): String? = scaffold.readFile(relativePath)
 
     fun addAppResource(path: String, content: String) {
         val file = dir.resolve("app/src/main/res/$path")
@@ -149,21 +95,7 @@ internal class AndroidProject(
     }
 
     override fun close() {
-        dir.deleteRecursively()
-    }
-
-    private fun findSdkDirFromLocalProperties(): String? {
-        var current: File? = File("").absoluteFile
-        while (current != null) {
-            val localProps = current.resolve("local.properties")
-            if (localProps.exists()) {
-                val props = java.util.Properties().apply { localProps.reader().use { load(it) } }
-                val sdkDir = props.getProperty("sdk.dir")
-                if (sdkDir != null) return sdkDir
-            }
-            current = current.parentFile
-        }
-        return null
+        scaffold.delete()
     }
 
     companion object {

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidProject.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidProject.kt
@@ -13,7 +13,7 @@ internal class AndroidProject(
     val dir: File get() = scaffold.dir
 
     init {
-        scaffold.writeSettings("test-project", listOf(":app", ":module1"))
+        scaffold.writeSettings("test-project", ":app", ":module1")
         scaffold.writeRootBuildscript()
         scaffold.writeGradleProperties()
         scaffold.writeLocalProperties()
@@ -76,7 +76,7 @@ internal class AndroidProject(
             """.trimIndent()
         )
 
-        val module1SrcDir = module1Dir.resolve("src/main").apply { mkdirs() }
+        val module1SrcDir = module1Dir.resolve("src/main")
         scaffold.writeEmptyManifest(module1SrcDir.resolve("AndroidManifest.xml"))
 
         for ((path, content) in moduleResources) {

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidXValuesProject.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidXValuesProject.kt
@@ -1,8 +1,7 @@
 package io.github.fornewid.gradle.plugins.highlander.fixture
 
-import java.io.File
 import java.io.ByteArrayOutputStream
-import java.util.UUID
+import java.io.File
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -15,59 +14,18 @@ internal class AndroidXValuesProject(
     private val excludeAndroidXValues: Boolean,
 ) : AutoCloseable {
 
-    val dir: File = File("build/gradleTest/${UUID.randomUUID()}").apply { mkdirs() }
+    private val scaffold: TestProjectScaffold = TestProjectScaffold.create()
+
+    val dir: File get() = scaffold.dir
 
     init {
-        val pluginJar = System.getProperty("pluginJar")
-            ?: error("pluginJar system property not set. Run via '../gradlew gradleTest'")
-        val escapedJar = pluginJar.replace("\\", "/")
-
         val localRepo = dir.resolve("local-maven-repo").apply { mkdirs() }
         publishFakeAndroidXAar(localRepo)
-        val escapedRepo = localRepo.absolutePath.replace("\\", "/")
 
-        dir.resolve("settings.gradle").writeText(
-            """
-            rootProject.name = "test-project"
-            include ':app'
-            """.trimIndent()
-        )
-
-        dir.resolve("build.gradle").writeText(
-            """
-            buildscript {
-                repositories {
-                    google()
-                    mavenCentral()
-                    maven { url '$escapedRepo' }
-                }
-                dependencies {
-                    classpath 'com.android.tools.build:gradle:8.5.0'
-                    classpath files('$escapedJar')
-                }
-            }
-            allprojects {
-                repositories {
-                    google()
-                    mavenCentral()
-                    maven { url '$escapedRepo' }
-                }
-            }
-            """.trimIndent()
-        )
-
-        dir.resolve("gradle.properties").writeText(
-            """
-            android.useAndroidX=true
-            org.gradle.jvmargs=-Xmx1g
-            """.trimIndent()
-        )
-
-        val androidHome = System.getenv("ANDROID_HOME")
-            ?: System.getenv("ANDROID_SDK_ROOT")
-            ?: findSdkDirFromLocalProperties()
-            ?: error("ANDROID_HOME or ANDROID_SDK_ROOT must be set")
-        dir.resolve("local.properties").writeText("sdk.dir=$androidHome")
+        scaffold.writeSettings("test-project", listOf(":app"))
+        scaffold.writeRootBuildscript(extraRepoUrls = listOf(localRepo.absolutePath))
+        scaffold.writeGradleProperties()
+        scaffold.writeLocalProperties()
 
         val appDir = dir.resolve("app").apply { mkdirs() }
         appDir.resolve("build.gradle").writeText(
@@ -124,13 +82,10 @@ internal class AndroidXValuesProject(
         )
     }
 
-    fun readFile(relativePath: String): String? {
-        val file = dir.resolve(relativePath)
-        return if (file.exists()) file.readText() else null
-    }
+    fun readFile(relativePath: String): String? = scaffold.readFile(relativePath)
 
     override fun close() {
-        dir.deleteRecursively()
+        scaffold.delete()
     }
 
     private fun publishFakeAndroidXAar(repoDir: File) {
@@ -185,19 +140,5 @@ internal class AndroidXValuesProject(
             </project>
             """.trimIndent()
         )
-    }
-
-    private fun findSdkDirFromLocalProperties(): String? {
-        var current: File? = File("").absoluteFile
-        while (current != null) {
-            val localProps = current.resolve("local.properties")
-            if (localProps.exists()) {
-                val props = java.util.Properties().apply { localProps.reader().use { load(it) } }
-                val sdkDir = props.getProperty("sdk.dir")
-                if (sdkDir != null) return sdkDir
-            }
-            current = current.parentFile
-        }
-        return null
     }
 }

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidXValuesProject.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidXValuesProject.kt
@@ -22,7 +22,7 @@ internal class AndroidXValuesProject(
         val localRepo = dir.resolve("local-maven-repo").apply { mkdirs() }
         publishFakeAndroidXAar(localRepo)
 
-        scaffold.writeSettings("test-project", listOf(":app"))
+        scaffold.writeSettings("test-project", ":app")
         scaffold.writeRootBuildscript(extraRepoUrls = listOf(localRepo.absolutePath))
         scaffold.writeGradleProperties()
         scaffold.writeLocalProperties()

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/TestProjectScaffold.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/TestProjectScaffold.kt
@@ -1,0 +1,125 @@
+package io.github.fornewid.gradle.plugins.highlander.fixture
+
+import java.io.File
+import java.util.Properties
+import java.util.UUID
+
+/**
+ * Shared scaffolding for gradleTest project fixtures. Owns the temporary project
+ * directory and writes the boilerplate (settings, root build.gradle, gradle.properties,
+ * local.properties) that every Android gradleTest needs.
+ *
+ * Fixtures compose this with their project-specific layout (modules, AARs, resources).
+ */
+internal class TestProjectScaffold private constructor(val dir: File) {
+
+    fun writeSettings(rootName: String, includes: List<String>) {
+        val text = buildString {
+            append("""rootProject.name = "$rootName"""").append('\n')
+            for (path in includes) append("include '$path'").append('\n')
+        }
+        dir.resolve("settings.gradle").writeText(text.trimEnd())
+    }
+
+    fun writeRootBuildscript(
+        agpVersion: String = DEFAULT_AGP_VERSION,
+        extraRepoUrls: List<String> = emptyList(),
+    ) {
+        val escapedJar = pluginJar.replace("\\", "/")
+        val extraRepos = if (extraRepoUrls.isEmpty()) {
+            ""
+        } else {
+            "\n                    " + extraRepoUrls.joinToString(separator = "\n                    ") {
+                "maven { url '${it.replace("\\", "/")}' }"
+            }
+        }
+        dir.resolve("build.gradle").writeText(
+            """
+            buildscript {
+                repositories {
+                    google()
+                    mavenCentral()$extraRepos
+                }
+                dependencies {
+                    classpath 'com.android.tools.build:gradle:$agpVersion'
+                    classpath files('$escapedJar')
+                }
+            }
+            allprojects {
+                repositories {
+                    google()
+                    mavenCentral()$extraRepos
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    fun readFile(relativePath: String): String? {
+        val file = dir.resolve(relativePath)
+        return if (file.exists()) file.readText() else null
+    }
+
+    fun writeGradleProperties() {
+        dir.resolve("gradle.properties").writeText(
+            """
+            android.useAndroidX=true
+            org.gradle.jvmargs=-Xmx1g
+            """.trimIndent()
+        )
+    }
+
+    fun writeLocalProperties() {
+        dir.resolve("local.properties").writeText("sdk.dir=${resolveAndroidHome()}")
+    }
+
+    fun writeEmptyManifest(target: File) {
+        target.parentFile.mkdirs()
+        target.writeText(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+            """.trimIndent()
+        )
+    }
+
+    fun delete() {
+        dir.deleteRecursively()
+    }
+
+    companion object {
+
+        const val DEFAULT_AGP_VERSION: String = "8.5.0"
+
+        fun create(): TestProjectScaffold {
+            val dir = File("build/gradleTest/${UUID.randomUUID()}").apply { mkdirs() }
+            return TestProjectScaffold(dir)
+        }
+
+        private val pluginJar: String by lazy {
+            System.getProperty("pluginJar")
+                ?: error("pluginJar system property not set. Run via '../gradlew gradleTest'")
+        }
+
+        private fun resolveAndroidHome(): String {
+            return System.getenv("ANDROID_HOME")
+                ?: System.getenv("ANDROID_SDK_ROOT")
+                ?: findSdkDirFromLocalProperties()
+                ?: error("ANDROID_HOME or ANDROID_SDK_ROOT must be set")
+        }
+
+        private fun findSdkDirFromLocalProperties(): String? {
+            var current: File? = File("").absoluteFile
+            while (current != null) {
+                val localProps = current.resolve("local.properties")
+                if (localProps.exists()) {
+                    val props = Properties().apply { localProps.reader().use { load(it) } }
+                    val sdkDir = props.getProperty("sdk.dir")
+                    if (sdkDir != null) return sdkDir
+                }
+                current = current.parentFile
+            }
+            return null
+        }
+    }
+}

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/TestProjectScaffold.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/TestProjectScaffold.kt
@@ -13,7 +13,7 @@ import java.util.UUID
  */
 internal class TestProjectScaffold private constructor(val dir: File) {
 
-    fun writeSettings(rootName: String, includes: List<String>) {
+    fun writeSettings(rootName: String, vararg includes: String) {
         val text = buildString {
             append("""rootProject.name = "$rootName"""").append('\n')
             for (path in includes) append("include '$path'").append('\n')
@@ -29,7 +29,7 @@ internal class TestProjectScaffold private constructor(val dir: File) {
         val extraRepos = if (extraRepoUrls.isEmpty()) {
             ""
         } else {
-            "\n                    " + extraRepoUrls.joinToString(separator = "\n                    ") {
+            "\n        " + extraRepoUrls.joinToString(separator = "\n        ") {
                 "maven { url '${it.replace("\\", "/")}' }"
             }
         }
@@ -55,11 +55,6 @@ internal class TestProjectScaffold private constructor(val dir: File) {
         )
     }
 
-    fun readFile(relativePath: String): String? {
-        val file = dir.resolve(relativePath)
-        return if (file.exists()) file.readText() else null
-    }
-
     fun writeGradleProperties() {
         dir.resolve("gradle.properties").writeText(
             """
@@ -70,7 +65,8 @@ internal class TestProjectScaffold private constructor(val dir: File) {
     }
 
     fun writeLocalProperties() {
-        dir.resolve("local.properties").writeText("sdk.dir=${resolveAndroidHome()}")
+        val escaped = androidHome.replace("\\", "/")
+        dir.resolve("local.properties").writeText("sdk.dir=$escaped")
     }
 
     fun writeEmptyManifest(target: File) {
@@ -81,6 +77,11 @@ internal class TestProjectScaffold private constructor(val dir: File) {
             <manifest xmlns:android="http://schemas.android.com/apk/res/android" />
             """.trimIndent()
         )
+    }
+
+    fun readFile(relativePath: String): String? {
+        val file = dir.resolve(relativePath)
+        return if (file.exists()) file.readText() else null
     }
 
     fun delete() {
@@ -96,13 +97,13 @@ internal class TestProjectScaffold private constructor(val dir: File) {
             return TestProjectScaffold(dir)
         }
 
-        private val pluginJar: String by lazy {
+        internal val pluginJar: String by lazy {
             System.getProperty("pluginJar")
                 ?: error("pluginJar system property not set. Run via '../gradlew gradleTest'")
         }
 
-        private fun resolveAndroidHome(): String {
-            return System.getenv("ANDROID_HOME")
+        private val androidHome: String by lazy {
+            System.getenv("ANDROID_HOME")
                 ?: System.getenv("ANDROID_SDK_ROOT")
                 ?: findSdkDirFromLocalProperties()
                 ?: error("ANDROID_HOME or ANDROID_SDK_ROOT must be set")


### PR DESCRIPTION
## Summary

`AndroidProject` and `AndroidXValuesProject` duplicated ~70% of their init: temp dir, plugin-jar resolution, `settings.gradle`, root `build.gradle` with AGP + plugin classpath, `gradle.properties`, `local.properties` with SDK lookup, and empty manifest writing.

Extract that boilerplate into a new `TestProjectScaffold`:

- `create()` companion factory produces a UUID-based `build/gradleTest/...` dir.
- Instance methods: `writeSettings`, `writeRootBuildscript` (optional `extraRepoUrls` to inject into both buildscript and allprojects blocks), `writeGradleProperties`, `writeLocalProperties`, `writeEmptyManifest`, `readFile`, `delete`.
- Plugin-jar path and SDK lookup live on the companion (lazy) so they run once per process.
- `writeRootBuildscript` emits no blank line when `extraRepoUrls` is empty — output matches the previous inline code exactly.
- Settings file uses explicit `"\n"` rather than `appendLine` to stay platform-independent.

`AndroidProject.kt`: 180 → 114 lines. Keeps the `:app` + `:module1` layout and parameterized pluginConfig / resources.
`AndroidXValuesProject.kt`: 198 → 128 lines. Passes the local maven repo via `extraRepoUrls` instead of re-writing the whole buildscript.

Refs #22

## Test plan

- [x] `:highlander:test`
- [x] `:highlander:gradleTest --rerun-tasks` (CC strict mode)

## Follow-up

- #27 — further dedup the app-module `build.gradle` skeleton + non-empty `AndroidManifest.xml` shared between the two fixtures.