### PR TITLE
Classify byte-identical resource/asset duplicates as duplicate-safe

### DIFF
--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
@@ -109,6 +109,58 @@ internal class HighlanderPluginTest {
     }
 
     @Test
+    fun `baseline emits duplicate-safe for byte-identical resources from external deps`() {
+        // Two dependencies with identical-byte resources → classified as duplicate-safe.
+        // We use Unknown-origin sources (from files()-style local AAR) to avoid the
+        // app-module override promotion path.
+        AndroidProject(
+            appResources = mapOf("drawable/ic_app_only.xml" to "<app/>"),
+            moduleResources = mapOf("drawable/ic_same.xml" to "<vector/>"),
+        ).use { project ->
+            // Add a second source with identical byte content in :module1 and :app.
+            project.addAppResource("drawable/ic_same.xml", "<vector/>")
+
+            build(project, ":app:highlanderBaselineRelease")
+
+            val baseline = project.readFile("app/highlander/releaseResources.txt")!!
+            // App module is one source of the byte-identical duplicate, but
+            // duplicate-safe is not promoted to override.
+            assertThat(baseline).contains("# duplicate-safe")
+            assertThat(baseline).contains("drawable/ic_same")
+        }
+    }
+
+    @Test
+    fun `baseline emits override for app-module conflicts with divergent content`() {
+        AndroidProject(
+            appResources = mapOf("drawable/ic_same.xml" to "<vector/>"),
+            moduleResources = mapOf("drawable/ic_same.xml" to "<shape/>"),
+        ).use { project ->
+            build(project, ":app:highlanderBaselineRelease")
+
+            val baseline = project.readFile("app/highlander/releaseResources.txt")!!
+            assertThat(baseline).contains("# override")
+            assertThat(baseline).contains("drawable/ic_same")
+        }
+    }
+
+    @Test
+    fun `guard fails with classification flip diff when conflict becomes duplicate-safe`() {
+        AndroidProject(
+            appResources = mapOf("drawable/ic_same.xml" to "<vector/>"),
+            moduleResources = mapOf("drawable/ic_same.xml" to "<shape/>"),
+        ).use { project ->
+            build(project, ":app:highlanderBaselineRelease")
+            // Flip: make app's copy byte-identical to module's.
+            project.addAppResource("drawable/ic_same.xml", "<shape/>")
+
+            val result = buildAndFail(project, ":app:highlanderRelease")
+            assertThat(result.output).contains("drawable/ic_same")
+            assertThat(result.output).contains("override -> duplicate-safe")
+        }
+    }
+
+    @Test
     fun `no baseline file created when scan type disabled`() {
         val pluginConfig = """
             highlander {

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/BaselineFormat.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/BaselineFormat.kt
@@ -58,8 +58,11 @@ internal object BaselineFormat {
                 line.isBlank() -> continue
                 line.startsWith("#") -> {
                     val match = TAG_LINE.matchEntire(line)
-                    if (match != null) {
-                        pendingClassification = Classification.fromTag(match.groupValues[1])
+                    pendingClassification = if (match != null) {
+                        Classification.fromTag(match.groupValues[1])
+                    } else {
+                        // Non-tag comment — don't let a stale pending tag leak to the next entry.
+                        Classification.CONFLICT
                     }
                 }
                 line.endsWith(":") && !line.startsWith("  ") -> {

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/BaselineFormat.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/BaselineFormat.kt
@@ -1,5 +1,6 @@
 package io.github.fornewid.gradle.plugins.highlander.internal
 
+import io.github.fornewid.gradle.plugins.highlander.internal.models.Classification
 import io.github.fornewid.gradle.plugins.highlander.internal.models.DuplicateEntry
 import io.github.fornewid.gradle.plugins.highlander.internal.models.SourceOrigin
 
@@ -12,20 +13,22 @@ import io.github.fornewid.gradle.plugins.highlander.internal.models.SourceOrigin
  * drawable/ic_close:
  *   - :app (.xml)
  *   - com.example:lib:1.0 (.png)
+ * # duplicate-safe
+ * drawable/ic_pause_circle_filled:
+ *   - androidx.media3:media3-ui:1.4.1 (.xml)
+ *   - com.google.android.exoplayer:exoplayer-ui:2.18.7 (.xml)
  * ```
  */
 internal object BaselineFormat {
 
     private val SOURCE_WITH_EXT = Regex("""^(.+?)\s+\((\.\w+)\)$""")
+    private val TAG_LINE = Regex("""^#\s*(\S+)\s*$""")
 
-    fun serialize(entries: List<DuplicateEntry>, appModulePath: String? = null): String {
+    fun serialize(entries: List<DuplicateEntry>): String {
         if (entries.isEmpty()) return ""
         val sb = StringBuilder()
         for (entry in entries) {
-            if (appModulePath != null) {
-                val tag = if (entry.sources.any { it.displayName == appModulePath }) "override" else "conflict"
-                sb.appendLine("# $tag")
-            }
+            sb.appendLine("# ${entry.classification.tag}")
             sb.appendLine("${entry.resourceKey}:")
             for (source in entry.sources) {
                 val ext = entry.extensions[source.displayName]
@@ -46,16 +49,28 @@ internal object BaselineFormat {
         var currentKey: String? = null
         var currentSources = mutableListOf<SourceOrigin>()
         var currentExtensions = mutableMapOf<String, String>()
+        var pendingClassification: Classification = Classification.CONFLICT
+        var currentClassification: Classification = Classification.CONFLICT
 
         for (rawLine in content.lines()) {
             val line = rawLine.trimEnd()
             when {
-                line.isBlank() || line.startsWith("#") -> continue
+                line.isBlank() -> continue
+                line.startsWith("#") -> {
+                    val match = TAG_LINE.matchEntire(line)
+                    if (match != null) {
+                        pendingClassification = Classification.fromTag(match.groupValues[1])
+                    }
+                }
                 line.endsWith(":") && !line.startsWith("  ") -> {
-                    flushEntry(entries, currentKey, currentSources, currentExtensions)
+                    flushEntry(entries, currentKey, currentSources, currentExtensions, currentClassification)
                     currentKey = line.removeSuffix(":")
                     currentSources = mutableListOf()
                     currentExtensions = mutableMapOf()
+                    currentClassification = pendingClassification
+                    // Reset pending so a subsequent entry without its own tag
+                    // defaults to CONFLICT rather than inheriting.
+                    pendingClassification = Classification.CONFLICT
                 }
                 line.startsWith("  - ") -> {
                     val raw = line.removePrefix("  - ")
@@ -72,7 +87,7 @@ internal object BaselineFormat {
                 }
             }
         }
-        flushEntry(entries, currentKey, currentSources, currentExtensions)
+        flushEntry(entries, currentKey, currentSources, currentExtensions, currentClassification)
 
         return entries
     }
@@ -82,9 +97,10 @@ internal object BaselineFormat {
         key: String?,
         sources: List<SourceOrigin>,
         extensions: Map<String, String>,
+        classification: Classification,
     ) {
         if (key != null && sources.isNotEmpty()) {
-            entries.add(DuplicateEntry(key, sources, extensions))
+            entries.add(DuplicateEntry(key, sources, extensions, classification))
         }
     }
 

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/ContentHasher.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/ContentHasher.kt
@@ -1,0 +1,38 @@
+package io.github.fornewid.gradle.plugins.highlander.internal
+
+import java.io.File
+import java.security.DigestInputStream
+import java.security.MessageDigest
+
+internal object ContentHasher {
+
+    private const val BUFFER_SIZE = 8 * 1024
+
+    /**
+     * SHA-256 digest of a file, streamed in fixed-size chunks. Returned as a
+     * lowercase hex string so the value is cheap to compare and hash.
+     */
+    fun sha256Hex(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().buffered(BUFFER_SIZE).use { input ->
+            DigestInputStream(input, digest).use { stream ->
+                val buffer = ByteArray(BUFFER_SIZE)
+                while (stream.read(buffer) != -1) {
+                    // DigestInputStream updates the digest via read().
+                }
+            }
+        }
+        return digest.digest().toHexString()
+    }
+
+    private fun ByteArray.toHexString(): String {
+        val sb = StringBuilder(size * 2)
+        for (b in this) {
+            sb.append(HEX[(b.toInt() ushr 4) and 0x0F])
+            sb.append(HEX[b.toInt() and 0x0F])
+        }
+        return sb.toString()
+    }
+
+    private val HEX = "0123456789abcdef".toCharArray()
+}

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/ContentHasher.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/ContentHasher.kt
@@ -14,7 +14,7 @@ internal object ContentHasher {
      */
     fun sha256Hex(file: File): String {
         val digest = MessageDigest.getInstance("SHA-256")
-        file.inputStream().buffered(BUFFER_SIZE).use { input ->
+        file.inputStream().use { input ->
             DigestInputStream(input, digest).use { stream ->
                 val buffer = ByteArray(BUFFER_SIZE)
                 while (stream.read(buffer) != -1) {
@@ -22,10 +22,10 @@ internal object ContentHasher {
                 }
             }
         }
-        return digest.digest().toHexString()
+        return digest.digest().toHex()
     }
 
-    private fun ByteArray.toHexString(): String {
+    private fun ByteArray.toHex(): String {
         val sb = StringBuilder(size * 2)
         for (b in this) {
             sb.append(HEX[(b.toInt() ushr 4) and 0x0F])

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/models/DuplicateEntry.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/models/DuplicateEntry.kt
@@ -2,27 +2,48 @@ package io.github.fornewid.gradle.plugins.highlander.internal.models
 
 import java.io.Serializable
 
+internal enum class Classification(val tag: String) {
+    CONFLICT("conflict"),
+    OVERRIDE("override"),
+    DUPLICATE_SAFE("duplicate-safe"),
+    ;
+
+    companion object {
+        fun fromTag(tag: String?): Classification {
+            if (tag == null) return CONFLICT
+            return values().firstOrNull { it.tag == tag } ?: CONFLICT
+        }
+    }
+}
+
 internal class DuplicateEntry(
     val resourceKey: String,
     val sources: List<SourceOrigin>,
     /** File extension per source display name, e.g., {":app" to ".xml"} */
     val extensions: Map<String, String> = emptyMap(),
+    val classification: Classification = Classification.CONFLICT,
 ) : Serializable, Comparable<DuplicateEntry> {
 
     override fun compareTo(other: DuplicateEntry): Int = resourceKey.compareTo(other.resourceKey)
 
-    // Equality based on resourceKey and sources only (extensions are informational)
+    // Equality based on resourceKey, sources, and classification.
+    // Classification is included so guard diffs fire when an entry flips between
+    // conflict / override / duplicate-safe even if the key and sources are unchanged.
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is DuplicateEntry) return false
-        return resourceKey == other.resourceKey && sources == other.sources
+        return resourceKey == other.resourceKey &&
+            sources == other.sources &&
+            classification == other.classification
     }
 
     override fun hashCode(): Int {
         var result = resourceKey.hashCode()
         result = 31 * result + sources.hashCode()
+        result = 31 * result + classification.hashCode()
         return result
     }
 
-    override fun toString(): String = "DuplicateEntry(resourceKey=$resourceKey, sources=$sources)"
+    override fun toString(): String =
+        "DuplicateEntry(resourceKey=$resourceKey, sources=$sources, classification=$classification)"
 }

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/AssetScanner.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/AssetScanner.kt
@@ -1,5 +1,7 @@
 package io.github.fornewid.gradle.plugins.highlander.internal.scanner
 
+import io.github.fornewid.gradle.plugins.highlander.internal.ContentHasher
+import io.github.fornewid.gradle.plugins.highlander.internal.models.Classification
 import io.github.fornewid.gradle.plugins.highlander.internal.models.DuplicateEntry
 import io.github.fornewid.gradle.plugins.highlander.internal.models.SourceOrigin
 import java.io.File
@@ -9,7 +11,8 @@ internal object AssetScanner {
     fun scan(
         sources: List<Pair<File, SourceOrigin>>,
     ): List<DuplicateEntry> {
-        val assetMap = mutableMapOf<String, MutableSet<SourceOrigin>>()
+        // key -> (source -> File)
+        val assetMap = mutableMapOf<String, MutableMap<SourceOrigin, File>>()
 
         for ((dir, source) in sources) {
             if (!dir.exists() || !dir.isDirectory) continue
@@ -18,22 +21,34 @@ internal object AssetScanner {
 
         return assetMap
             .filter { it.value.size > 1 }
-            .map { (key, origins) -> DuplicateEntry(key, origins.sorted()) }
+            .map { (key, sourceMap) ->
+                val classification = classify(sourceMap.values)
+                DuplicateEntry(
+                    resourceKey = key,
+                    sources = sourceMap.keys.sorted(),
+                    classification = classification,
+                )
+            }
             .sorted()
+    }
+
+    private fun classify(files: Collection<File>): Classification {
+        val hashes = files.mapTo(HashSet()) { ContentHasher.sha256Hex(it) }
+        return if (hashes.size == 1) Classification.DUPLICATE_SAFE else Classification.CONFLICT
     }
 
     private fun collectAssets(
         baseDir: File,
         currentDir: File,
         source: SourceOrigin,
-        assetMap: MutableMap<String, MutableSet<SourceOrigin>>,
+        assetMap: MutableMap<String, MutableMap<SourceOrigin, File>>,
     ) {
         val entries = currentDir.listFiles() ?: return
 
         for (entry in entries) {
             if (entry.isFile) {
                 val key = entry.relativeTo(baseDir).invariantSeparatorsPath
-                assetMap.getOrPut(key) { mutableSetOf() }.add(source)
+                assetMap.getOrPut(key) { mutableMapOf() }.putIfAbsent(source, entry)
             } else if (entry.isDirectory) {
                 collectAssets(baseDir, entry, source, assetMap)
             }

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ResourceScanner.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ResourceScanner.kt
@@ -1,16 +1,20 @@
 package io.github.fornewid.gradle.plugins.highlander.internal.scanner
 
+import io.github.fornewid.gradle.plugins.highlander.internal.ContentHasher
+import io.github.fornewid.gradle.plugins.highlander.internal.models.Classification
 import io.github.fornewid.gradle.plugins.highlander.internal.models.DuplicateEntry
 import io.github.fornewid.gradle.plugins.highlander.internal.models.SourceOrigin
 import java.io.File
 
 internal object ResourceScanner {
 
+    private data class FileEntry(val file: File, val ext: String)
+
     fun scan(
         sources: List<Pair<File, SourceOrigin>>,
     ): List<DuplicateEntry> {
-        // key -> (source -> extension)
-        val resourceMap = mutableMapOf<String, MutableMap<SourceOrigin, String>>()
+        // key -> (source -> FileEntry)
+        val resourceMap = mutableMapOf<String, MutableMap<SourceOrigin, FileEntry>>()
 
         for ((dir, source) in sources) {
             if (!dir.exists() || !dir.isDirectory) continue
@@ -19,20 +23,27 @@ internal object ResourceScanner {
 
         return resourceMap
             .filter { it.value.size > 1 }
-            .map { (key, sourceExtMap) ->
+            .map { (key, sourceMap) ->
+                val classification = classify(sourceMap.values.map { it.file })
                 DuplicateEntry(
                     resourceKey = key,
-                    sources = sourceExtMap.keys.sorted(),
-                    extensions = sourceExtMap.mapKeys { it.key.displayName },
+                    sources = sourceMap.keys.sorted(),
+                    extensions = sourceMap.mapKeys { it.key.displayName }.mapValues { it.value.ext },
+                    classification = classification,
                 )
             }
             .sorted()
     }
 
+    private fun classify(files: Collection<File>): Classification {
+        val hashes = files.mapTo(HashSet()) { ContentHasher.sha256Hex(it) }
+        return if (hashes.size == 1) Classification.DUPLICATE_SAFE else Classification.CONFLICT
+    }
+
     private fun collectResources(
         resDir: File,
         source: SourceOrigin,
-        resourceMap: MutableMap<String, MutableMap<SourceOrigin, String>>,
+        resourceMap: MutableMap<String, MutableMap<SourceOrigin, FileEntry>>,
     ) {
         val typeDirs = resDir.listFiles()?.filter { it.isDirectory } ?: return
 
@@ -46,7 +57,7 @@ internal object ResourceScanner {
                 val resourceName = if (file.name.endsWith(".9.png")) baseName.removeSuffix(".9") else baseName
                 val key = "$dirName/$resourceName"
                 val ext = ".${file.extension}"
-                resourceMap.getOrPut(key) { mutableMapOf() }.putIfAbsent(source, ext)
+                resourceMap.getOrPut(key) { mutableMapOf() }.putIfAbsent(source, FileEntry(file, ext))
             }
         }
     }

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
@@ -2,6 +2,7 @@ package io.github.fornewid.gradle.plugins.highlander.internal.task
 
 import io.github.fornewid.gradle.plugins.highlander.HighlanderPlugin
 import io.github.fornewid.gradle.plugins.highlander.internal.BaselineFormat
+import io.github.fornewid.gradle.plugins.highlander.internal.models.Classification
 import io.github.fornewid.gradle.plugins.highlander.internal.models.DuplicateEntry
 import io.github.fornewid.gradle.plugins.highlander.internal.models.SourceOrigin
 import io.github.fornewid.gradle.plugins.highlander.internal.scanner.AssetScanner
@@ -156,7 +157,8 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
         current: List<DuplicateEntry>,
         isBaseline: Boolean,
     ): String? {
-        val currentContent = BaselineFormat.serialize(current, appModulePath = projectPath.get())
+        val promoted = current.map { promoteAppOverride(it) }
+        val currentContent = BaselineFormat.serialize(promoted)
 
         if (isBaseline) {
             file.writeText(currentContent)
@@ -178,21 +180,39 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
         if (currentContent == expectedContent) return null
 
         val expected = BaselineFormat.parse(expectedContent)
-        val added = current.filter { it !in expected }
-        val removed = expected.filter { it !in current }
+        val added = promoted.filter { it !in expected }
+        val removed = expected.filter { it !in promoted }
 
         if (added.isEmpty() && removed.isEmpty()) return null
 
+        // Same key present in both sides = classification flip. Render those as
+        // a single `~` line with the tag transition so the common "re-baseline
+        // after upgrade" case is readable.
+        val addedByKey = added.associateBy { it.resourceKey }
+        val removedByKey = removed.associateBy { it.resourceKey }
+        val flippedKeys = addedByKey.keys intersect removedByKey.keys
+        val pureRemoved = removed.filter { it.resourceKey !in flippedKeys }
+        val pureAdded = added.filter { it.resourceKey !in flippedKeys }
+
         return buildString {
             appendLine("=== $label ===")
-            for (entry in removed) {
+            for (key in flippedKeys.sorted()) {
+                val before = removedByKey.getValue(key)
+                val after = addedByKey.getValue(key)
+                appendLine("~ $key (${before.classification.tag} -> ${after.classification.tag}):")
+                for (source in after.sources) {
+                    val ext = after.extensions[source.displayName]?.let { " ($it)" } ?: ""
+                    appendLine("    - ${source.displayName}$ext")
+                }
+            }
+            for (entry in pureRemoved) {
                 appendLine("- ${entry.resourceKey}:")
                 for (source in entry.sources) {
                     val ext = entry.extensions[source.displayName]?.let { " ($it)" } ?: ""
                     appendLine("-   - ${source.displayName}$ext")
                 }
             }
-            for (entry in added) {
+            for (entry in pureAdded) {
                 appendLine("+ ${entry.resourceKey}:")
                 for (source in entry.sources) {
                     val ext = entry.extensions[source.displayName]?.let { " ($it)" } ?: ""
@@ -200,6 +220,22 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
                 }
             }
         }
+    }
+
+    // Scanners emit CONFLICT or DUPLICATE_SAFE based on byte comparison. Promote
+    // CONFLICT to OVERRIDE when the app module itself is one of the sources —
+    // that context is only available to the task. DUPLICATE_SAFE is left alone:
+    // a byte-identical file in the app module is still not a real conflict.
+    private fun promoteAppOverride(entry: DuplicateEntry): DuplicateEntry {
+        if (entry.classification != Classification.CONFLICT) return entry
+        val appModule = SourceOrigin.Module(projectPath.get())
+        if (appModule !in entry.sources) return entry
+        return DuplicateEntry(
+            resourceKey = entry.resourceKey,
+            sources = entry.sources,
+            extensions = entry.extensions,
+            classification = Classification.OVERRIDE,
+        )
     }
 
     private fun scanRes(): List<DuplicateEntry> {

--- a/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/BaselineFormatTest.kt
+++ b/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/BaselineFormatTest.kt
@@ -1,6 +1,7 @@
 package io.github.fornewid.gradle.plugins.highlander.internal
 
 import com.google.common.truth.Truth.assertThat
+import io.github.fornewid.gradle.plugins.highlander.internal.models.Classification
 import io.github.fornewid.gradle.plugins.highlander.internal.models.DuplicateEntry
 import io.github.fornewid.gradle.plugins.highlander.internal.models.SourceOrigin
 import org.junit.jupiter.api.Test
@@ -10,22 +11,41 @@ internal class BaselineFormatTest {
     @Test
     fun `serialize produces expected format`() {
         val entries = listOf(
-            DuplicateEntry("drawable/ic_close", listOf(
-                SourceOrigin.Module(":app"),
-                SourceOrigin.ExternalDependency("com.example:lib:1.0"),
-            )),
+            DuplicateEntry(
+                "drawable/ic_close",
+                listOf(
+                    SourceOrigin.Module(":app"),
+                    SourceOrigin.ExternalDependency("com.example:lib:1.0"),
+                ),
+                classification = Classification.OVERRIDE,
+            ),
         )
 
         val result = BaselineFormat.serialize(entries)
 
         assertThat(result).isEqualTo(
             """
+            # override
             drawable/ic_close:
               - :app
               - com.example:lib:1.0
 
             """.trimIndent()
         )
+    }
+
+    @Test
+    fun `serialize defaults to conflict tag`() {
+        val entries = listOf(
+            DuplicateEntry(
+                "drawable/ic_close",
+                listOf(SourceOrigin.Module(":app"), SourceOrigin.Module(":module1")),
+            ),
+        )
+
+        val result = BaselineFormat.serialize(entries)
+
+        assertThat(result).startsWith("# conflict\n")
     }
 
     @Test
@@ -36,14 +56,19 @@ internal class BaselineFormatTest {
     @Test
     fun `parse roundtrips correctly`() {
         val entries = listOf(
-            DuplicateEntry("drawable/ic_close", listOf(
-                SourceOrigin.Module(":app"),
-                SourceOrigin.Module(":module1"),
-            )),
-            DuplicateEntry("layout/item_row", listOf(
-                SourceOrigin.Module(":app"),
-                SourceOrigin.ExternalDependency("com.example:ui:2.0"),
-            )),
+            DuplicateEntry(
+                "drawable/ic_close",
+                listOf(SourceOrigin.Module(":app"), SourceOrigin.Module(":module1")),
+                classification = Classification.OVERRIDE,
+            ),
+            DuplicateEntry(
+                "layout/item_row",
+                listOf(
+                    SourceOrigin.Module(":app"),
+                    SourceOrigin.ExternalDependency("com.example:ui:2.0"),
+                ),
+                classification = Classification.OVERRIDE,
+            ),
         )
 
         val serialized = BaselineFormat.serialize(entries)
@@ -53,12 +78,123 @@ internal class BaselineFormatTest {
     }
 
     @Test
+    fun `parses duplicate-safe tag and roundtrips`() {
+        val entries = listOf(
+            DuplicateEntry(
+                "drawable/ic_share",
+                listOf(
+                    SourceOrigin.ExternalDependency("com.example:alpha:1.0"),
+                    SourceOrigin.ExternalDependency("com.example:beta:1.0"),
+                ),
+                classification = Classification.DUPLICATE_SAFE,
+            ),
+        )
+
+        val serialized = BaselineFormat.serialize(entries)
+        assertThat(serialized).startsWith("# duplicate-safe\n")
+
+        val parsed = BaselineFormat.parse(serialized)
+        assertThat(parsed).isEqualTo(entries)
+    }
+
+    @Test
+    fun `parses mixed tags across entries`() {
+        val content = """
+            # override
+            drawable/a:
+              - :app
+              - com.x:lib:1.0
+            # conflict
+            drawable/b:
+              - com.x:lib:1.0
+              - com.y:lib:1.0
+            # duplicate-safe
+            drawable/c:
+              - com.x:lib:1.0
+              - com.y:lib:1.0
+        """.trimIndent()
+
+        val parsed = BaselineFormat.parse(content)
+
+        assertThat(parsed).hasSize(3)
+        assertThat(parsed[0].classification).isEqualTo(Classification.OVERRIDE)
+        assertThat(parsed[1].classification).isEqualTo(Classification.CONFLICT)
+        assertThat(parsed[2].classification).isEqualTo(Classification.DUPLICATE_SAFE)
+    }
+
+    @Test
+    fun `missing tag defaults to conflict`() {
+        val content = """
+            drawable/ic_close:
+              - :app
+              - :module1
+        """.trimIndent()
+
+        val parsed = BaselineFormat.parse(content)
+
+        assertThat(parsed).hasSize(1)
+        assertThat(parsed[0].classification).isEqualTo(Classification.CONFLICT)
+    }
+
+    @Test
+    fun `unknown tag falls back to conflict`() {
+        val content = """
+            # made-up-tag
+            drawable/ic_close:
+              - :app
+              - :module1
+        """.trimIndent()
+
+        val parsed = BaselineFormat.parse(content)
+
+        assertThat(parsed).hasSize(1)
+        assertThat(parsed[0].classification).isEqualTo(Classification.CONFLICT)
+    }
+
+    @Test
+    fun `consecutive entries without interleaved tag fall back to conflict`() {
+        val content = """
+            # duplicate-safe
+            drawable/a:
+              - :app
+              - :module1
+            drawable/b:
+              - :app
+              - :module1
+        """.trimIndent()
+
+        val parsed = BaselineFormat.parse(content)
+
+        assertThat(parsed).hasSize(2)
+        assertThat(parsed[0].classification).isEqualTo(Classification.DUPLICATE_SAFE)
+        // No explicit tag for b → default CONFLICT, not leaked from a.
+        assertThat(parsed[1].classification).isEqualTo(Classification.CONFLICT)
+    }
+
+    @Test
+    fun `classification affects equality`() {
+        val a = DuplicateEntry(
+            "drawable/ic_close",
+            listOf(SourceOrigin.Module(":app"), SourceOrigin.Module(":module1")),
+            classification = Classification.CONFLICT,
+        )
+        val b = DuplicateEntry(
+            "drawable/ic_close",
+            listOf(SourceOrigin.Module(":app"), SourceOrigin.Module(":module1")),
+            classification = Classification.DUPLICATE_SAFE,
+        )
+
+        assertThat(a).isNotEqualTo(b)
+    }
+
+    @Test
     fun `Unknown source origin roundtrips correctly`() {
         val entries = listOf(
-            DuplicateEntry("drawable/ic_close", listOf(
-                SourceOrigin.Module(":app"),
-                SourceOrigin.Unknown("fake-sdk.aar"),
-            )),
+            DuplicateEntry(
+                "drawable/ic_close",
+                listOf(SourceOrigin.Module(":app"), SourceOrigin.Unknown("fake-sdk.aar")),
+                classification = Classification.OVERRIDE,
+            ),
         )
 
         val serialized = BaselineFormat.serialize(entries)
@@ -78,6 +214,7 @@ internal class BaselineFormatTest {
                     SourceOrigin.ExternalDependency("com.example:lib:1.0"),
                 ),
                 mapOf(":app" to ".xml", "com.example:lib:1.0" to ".png"),
+                classification = Classification.OVERRIDE,
             ),
         )
 

--- a/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/BaselineFormatTest.kt
+++ b/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/BaselineFormatTest.kt
@@ -172,6 +172,24 @@ internal class BaselineFormatTest {
     }
 
     @Test
+    fun `non-tag comment line does not leak pending classification`() {
+        // A generic comment appearing after a tag must reset the pending state
+        // so the following entry falls back to CONFLICT, not the leaked tag.
+        val content = """
+            # duplicate-safe
+            # note: just a free-form comment
+            drawable/a:
+              - :app
+              - :module1
+        """.trimIndent()
+
+        val parsed = BaselineFormat.parse(content)
+
+        assertThat(parsed).hasSize(1)
+        assertThat(parsed[0].classification).isEqualTo(Classification.CONFLICT)
+    }
+
+    @Test
     fun `classification affects equality`() {
         val a = DuplicateEntry(
             "drawable/ic_close",

--- a/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/AssetScannerTest.kt
+++ b/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/AssetScannerTest.kt
@@ -1,6 +1,7 @@
 package io.github.fornewid.gradle.plugins.highlander.internal.scanner
 
 import com.google.common.truth.Truth.assertThat
+import io.github.fornewid.gradle.plugins.highlander.internal.models.Classification
 import io.github.fornewid.gradle.plugins.highlander.internal.models.SourceOrigin
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -64,6 +65,34 @@ internal class AssetScannerTest {
         ))
 
         assertThat(duplicates).isEmpty()
+    }
+
+    @Test
+    fun `byte-identical duplicates are classified as duplicate-safe`() {
+        val assetA = createAssetDir("assetA", mapOf("config.json" to """{"v":1}"""))
+        val assetB = createAssetDir("assetB", mapOf("config.json" to """{"v":1}"""))
+
+        val duplicates = AssetScanner.scan(listOf(
+            assetA to SourceOrigin.ExternalDependency("com.x:lib:1.0"),
+            assetB to SourceOrigin.ExternalDependency("com.y:lib:1.0"),
+        ))
+
+        assertThat(duplicates).hasSize(1)
+        assertThat(duplicates[0].classification).isEqualTo(Classification.DUPLICATE_SAFE)
+    }
+
+    @Test
+    fun `divergent content duplicates are classified as conflict`() {
+        val assetA = createAssetDir("assetA", mapOf("config.json" to """{"v":1}"""))
+        val assetB = createAssetDir("assetB", mapOf("config.json" to """{"v":2}"""))
+
+        val duplicates = AssetScanner.scan(listOf(
+            assetA to SourceOrigin.ExternalDependency("com.x:lib:1.0"),
+            assetB to SourceOrigin.ExternalDependency("com.y:lib:1.0"),
+        ))
+
+        assertThat(duplicates).hasSize(1)
+        assertThat(duplicates[0].classification).isEqualTo(Classification.CONFLICT)
     }
 
     private fun createAssetDir(name: String, files: Map<String, String>): File {

--- a/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ResourceScannerTest.kt
+++ b/highlander/src/test/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/scanner/ResourceScannerTest.kt
@@ -1,6 +1,7 @@
 package io.github.fornewid.gradle.plugins.highlander.internal.scanner
 
 import com.google.common.truth.Truth.assertThat
+import io.github.fornewid.gradle.plugins.highlander.internal.models.Classification
 import io.github.fornewid.gradle.plugins.highlander.internal.models.SourceOrigin
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -134,6 +135,8 @@ internal class ResourceScannerTest {
 
         assertThat(duplicates).hasSize(1)
         assertThat(duplicates[0].resourceKey).isEqualTo("drawable/ic_close")
+        // Different file bytes → real conflict.
+        assertThat(duplicates[0].classification).isEqualTo(Classification.CONFLICT)
     }
 
     @Test
@@ -145,6 +148,94 @@ internal class ResourceScannerTest {
         ))
 
         assertThat(duplicates).isEmpty()
+    }
+
+    @Test
+    fun `byte-identical duplicates are classified as duplicate-safe`() {
+        val content = "<vector xmlns:android=\"http://schemas.android.com/apk/res/android\"/>"
+        val moduleA = createResDir("moduleA", mapOf("drawable/ic_shared.xml" to content))
+        val moduleB = createResDir("moduleB", mapOf("drawable/ic_shared.xml" to content))
+
+        val duplicates = ResourceScanner.scan(listOf(
+            moduleA to SourceOrigin.ExternalDependency("com.x:lib:1.0"),
+            moduleB to SourceOrigin.ExternalDependency("com.y:lib:1.0"),
+        ))
+
+        assertThat(duplicates).hasSize(1)
+        assertThat(duplicates[0].classification).isEqualTo(Classification.DUPLICATE_SAFE)
+    }
+
+    @Test
+    fun `divergent content duplicates are classified as conflict`() {
+        val moduleA = createResDir("moduleA", mapOf(
+            "layout/main.xml" to "<LinearLayout/>",
+        ))
+        val moduleB = createResDir("moduleB", mapOf(
+            "layout/main.xml" to "<FrameLayout/>",
+        ))
+
+        val duplicates = ResourceScanner.scan(listOf(
+            moduleA to SourceOrigin.ExternalDependency("com.x:lib:1.0"),
+            moduleB to SourceOrigin.ExternalDependency("com.y:lib:1.0"),
+        ))
+
+        assertThat(duplicates).hasSize(1)
+        assertThat(duplicates[0].classification).isEqualTo(Classification.CONFLICT)
+    }
+
+    @Test
+    fun `mixed identical and divergent duplicates coexist`() {
+        val moduleA = createResDir("moduleA", mapOf(
+            "drawable/ic_same.xml" to "<vector/>",
+            "layout/main.xml" to "<LinearLayout/>",
+        ))
+        val moduleB = createResDir("moduleB", mapOf(
+            "drawable/ic_same.xml" to "<vector/>",
+            "layout/main.xml" to "<FrameLayout/>",
+        ))
+
+        val duplicates = ResourceScanner.scan(listOf(
+            moduleA to SourceOrigin.ExternalDependency("com.x:lib:1.0"),
+            moduleB to SourceOrigin.ExternalDependency("com.y:lib:1.0"),
+        ))
+
+        assertThat(duplicates).hasSize(2)
+        val byKey = duplicates.associateBy { it.resourceKey }
+        assertThat(byKey["drawable/ic_same"]!!.classification)
+            .isEqualTo(Classification.DUPLICATE_SAFE)
+        assertThat(byKey["layout/main"]!!.classification)
+            .isEqualTo(Classification.CONFLICT)
+    }
+
+    @Test
+    fun `identical content across three sources is duplicate-safe`() {
+        val content = "<vector/>"
+        val sources = (1..3).map { i ->
+            createResDir("module$i", mapOf("drawable/shared.xml" to content)) to
+                SourceOrigin.ExternalDependency("com.x:lib$i:1.0")
+        }
+
+        val duplicates = ResourceScanner.scan(sources)
+
+        assertThat(duplicates).hasSize(1)
+        assertThat(duplicates[0].classification).isEqualTo(Classification.DUPLICATE_SAFE)
+    }
+
+    @Test
+    fun `any divergent source across many sources flips to conflict`() {
+        val sources = listOf(
+            createResDir("moduleA", mapOf("drawable/shared.xml" to "<vector/>")) to
+                SourceOrigin.ExternalDependency("com.x:a:1.0"),
+            createResDir("moduleB", mapOf("drawable/shared.xml" to "<vector/>")) to
+                SourceOrigin.ExternalDependency("com.x:b:1.0"),
+            createResDir("moduleC", mapOf("drawable/shared.xml" to "<vector />")) to
+                SourceOrigin.ExternalDependency("com.x:c:1.0"),
+        )
+
+        val duplicates = ResourceScanner.scan(sources)
+
+        assertThat(duplicates).hasSize(1)
+        assertThat(duplicates[0].classification).isEqualTo(Classification.CONFLICT)
     }
 
     private fun createResDir(name: String, files: Map<String, String>): File {


### PR DESCRIPTION
## Summary

File-based scanners previously flagged every same-name file across dependencies as `# conflict` regardless of content. In the issue's reproducer (`androidx.media3:media3-ui` + `com.google.android.exoplayer:exoplayer-ui`), 241 of 244 entries (98.8%) were byte-identical — AGP deterministically picks one, runtime unaffected — and the other 3 were real divergent-content conflicts. The noise drowns out the signal.

This PR introduces a new `# duplicate-safe` classification alongside `# conflict` / `# override`:

- **`Classification`** enum (`CONFLICT`, `OVERRIDE`, `DUPLICATE_SAFE`) added to `DuplicateEntry`. Included in `equals`/`hashCode` so classification flips are caught by the guard's diff path, not silently accepted.
- **`ContentHasher`** (new) computes streamed SHA-256 via `DigestInputStream` with an 8KB buffer — constant memory regardless of file size.
- **`ResourceScanner`** and **`AssetScanner`** hash each duplicate source file and emit `DUPLICATE_SAFE` when every hash matches, `CONFLICT` otherwise. Hashing runs only on keys with >1 source (pre-existing filter).
- **`BaselineFormat.serialize`** always emits `# ${classification.tag}`; `parse` tracks the most recent `#` line and attaches it to the next entry. Missing/unknown tags default to `CONFLICT`, preserving compatibility with legacy baselines.
- **`HighlanderCheckTask.processBaseline`** promotes `CONFLICT` → `OVERRIDE` when the app module itself is among the sources. `DUPLICATE_SAFE` is left alone even when the app module is present — a byte-identical file in the app is still not a real conflict.
- Diff output collapses same-key flips into `~ key (oldTag -> newTag):` for readability; pure added / removed keep the existing `+` / `-` format.

### Scope

`ResourceScanner` + `AssetScanner` only. `ClassScanner` and `NativeLibScanner` are unchanged per the issue (duplicates there are rarer). Their entries still emit as `CONFLICT`/`OVERRIDE` via the default path — no behavior change.

Closes #30

## Migration note

Existing baselines parse fine (`# conflict` / `# override` map straight to enum values). On first `highlander` run after upgrade, byte-identical entries previously recorded as `# conflict` will be re-classified as `# duplicate-safe` and the guard will fail with a re-baseline prompt. Run once:

```
./gradlew :<project>:highlanderBaseline<Variant>
```

## Test plan

- [x] `:highlander:test` (new unit tests for `BaselineFormat` roundtrip/tags/equality, `ResourceScanner` + `AssetScanner` classification)
- [x] `:highlander:gradleTest --rerun-tasks` (CC strict mode; new cases: duplicate-safe in baseline, override on divergent content, classification flip diff)
- [x] `:highlander:apiCheck` (public API unchanged — `Classification` is `internal`)
- [x] `:sample:app:highlanderBaselineRelease --configuration-cache` stored, second run reused cache, guard passes