### PR TITLE
Update README and add AI Agent setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.fornewid.highlander/highlander)](https://central.sonatype.com/artifact/io.github.fornewid.highlander/highlander)
 [![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/io.github.fornewid.highlander)](https://plugins.gradle.org/plugin/io.github.fornewid.highlander)
 [![Build](https://github.com/fornewid/highlander/actions/workflows/build.yml/badge.svg)](https://github.com/fornewid/highlander/actions/workflows/build.yml)
-[![License](https://img.shields.io/github/license/fornewid/highlander)](https://github.com/fornewid/highlander/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/fornewid/highlander)](LICENSE)
 
 <img src="art/banner.png" alt="Highlander" width="400"/>
+
+> :warning: This project is in an experimental stage. APIs and behavior may change without notice.
 
 > **"There can be only one."**
 
@@ -75,11 +77,12 @@ highlander {
     baselineDir.set("highlander") // default
 
     configuration("release") {
-        resources = true          // Scan res/ file-based resources
-        assets = true             // Scan assets/
-        nativeLibs = false        // Scan .so native libraries
-        valuesResources = false   // Scan values/ XML entries (strings, colors, etc.)
-        classes = false           // Scan Java/Kotlin classes in JARs/AARs
+        resources = true               // Scan res/ file-based resources
+        assets = true                  // Scan assets/
+        nativeLibs = false             // Scan .so native libraries
+        valuesResources = false        // Scan values/ XML entries (strings, colors, etc.)
+        classes = false                // Scan Java/Kotlin classes in JARs/AARs
+        excludeAndroidXValues = true   // Drop androidx.* sources from the values scan
     }
 }
 ```
@@ -88,12 +91,17 @@ highlander {
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `resources` | `true` | Detect duplicate file-based resources (`drawable`, `layout`, `mipmap`, etc.) |
-| `assets` | `true` | Detect duplicate asset files |
+| `resources` | **`true`** | Detect duplicate file-based resources (`drawable`, `layout`, `mipmap`, etc.) |
+| `assets` | **`true`** | Detect duplicate asset files |
 | `nativeLibs` | `false` | Detect duplicate `.so` native libraries per ABI |
 | `valuesResources` | `false` | Detect duplicate values entries (`string`, `color`, `dimen`, etc.) |
 | `classes` | `false` | Detect duplicate Java/Kotlin classes across dependency JARs/AARs |
+| `excludeAndroidXValues` | **`true`** | Filter out `androidx.*` sources from the values scan only |
 | `baselineDir` | `"highlander"` | Directory for baseline files |
+
+**Note on `excludeAndroidXValues`**: AndroidX components (Compose, Core, etc.) routinely share benign values declarations by design. Filtering them out keeps the values baseline signal-to-noise high. Set to `false` to include AndroidX entries. No effect unless `valuesResources = true`.
+
+**Note on values id-slot skip**: the values scan automatically skips empty-body `<item type="id" name="..."/>` (and the shorthand `<id name="..."/>`) declarations. AAPT2 treats these as weak `Id` values that merge across libraries without runtime conflict, so reporting them would be false-positive noise.
 
 ## Baseline Files
 
@@ -103,12 +111,34 @@ Each scan type produces a separate baseline file:
 highlander/
 ├── releaseResources.txt     # res/ duplicates
 ├── releaseAssets.txt        # assets duplicates
-├── releaseNativeLibs.txt    # .so duplicates
-├── releaseValues.txt        # values entry duplicates
-└── releaseClasses.txt       # class duplicates
+├── releaseNativeLibs.txt    # .so duplicates         (if nativeLibs = true)
+├── releaseValues.txt        # values entry duplicates (if valuesResources = true)
+└── releaseClasses.txt       # class duplicates       (if classes = true)
 ```
 
-Entries are tagged as **override** (app overrides a library) or **conflict** (libraries clash):
+### Classification
+
+Each entry is tagged with one of three labels indicating how AGP will resolve the duplicate:
+
+| Tag | Meaning | Action |
+|-----|---------|--------|
+| `# override` | The app module is one of the sources — AAPT's "last wins" rule makes the app's copy win | Usually intentional |
+| `# conflict` | External dependencies only, file bytes differ — AGP picks one by priority, behavior can change | Review the diff |
+| `# duplicate-safe` | All sources have byte-identical content — AAPT merges deterministically, no runtime difference | Informational |
+
+Classification matrix by scan type:
+
+| Scan | `override` | `conflict` | `duplicate-safe` |
+|------|:---:|:---:|:---:|
+| `resources` | ✓ | ✓ | ✓ |
+| `assets` | ✓ | ✓ | ✓ |
+| `nativeLibs` | ✓ | ✓ | — |
+| `classes` | ✓ | ✓ | — |
+| `valuesResources` | ✓ | ✓ | — |
+
+`duplicate-safe` requires byte-level comparison, which is only performed for `resources` and `assets` today.
+
+### Example
 
 ```
 # override
@@ -120,12 +150,36 @@ drawable/ic_close:
 config.json:
   - com.sdk.a:core:1.0
   - com.sdk.b:analytics:2.0
+
+# duplicate-safe
+drawable-anydpi-v21/ic_shared:
+  - androidx.media3:media3-ui:1.4.1 (.xml)
+  - com.google.android.exoplayer:exoplayer-ui:2.18.7 (.xml)
 ```
+
+### Classification flips
+
+If a duplicate's classification changes (e.g. a dependency upgrade makes bytes match, turning `conflict` into `duplicate-safe`), the guard reports a single `~` line for that key:
+
+```
+~ drawable/ic_shared (conflict -> duplicate-safe):
+    - androidx.media3:media3-ui:1.4.1 (.xml)
+    - com.google.android.exoplayer:exoplayer-ui:2.18.7 (.xml)
+```
+
+Re-run `highlanderBaseline` to accept the transition.
 
 ## Requirements
 
 - Android Gradle Plugin **8.0.0** or higher
 - Gradle **8.0** or higher
+- Applied to `com.android.application` modules only. Library modules are not supported.
+
+## AI Agent Guide
+
+If you use an AI coding assistant (Claude Code, Copilot, Gemini, Cursor, etc.),
+reference the [setup guide](docs/setup-guide.md.txt) for accurate installation
+instructions and common pitfalls.
 
 ## Acknowledgments
 
@@ -133,18 +187,4 @@ Inspired by [dependency-guard](https://github.com/dropbox/dependency-guard) and 
 
 ## License
 
-```
-Copyright 2026 Sungyong An
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-```
+[Apache License 2.0](LICENSE)

--- a/docs/setup-guide.md.txt
+++ b/docs/setup-guide.md.txt
@@ -1,0 +1,213 @@
+# Highlander — AI Agent Setup Guide
+
+This guide helps AI agents (Claude Code, GitHub Copilot, Gemini, Cursor, etc.)
+correctly install and configure the Highlander Gradle plugin.
+
+## What is Highlander?
+
+A Gradle plugin that detects duplicate resources, assets, classes, and native
+libraries across an Android app's dependencies. It saves a baseline of the
+current duplicates and fails the build when new ones appear — catching silent
+UI bugs, Dex merge failures, and runtime `UnsatisfiedLinkError` before they ship.
+
+- Plugin ID: `io.github.fornewid.highlander`
+- Maven Central: `io.github.fornewid.highlander:highlander`
+- Minimum: AGP 8.0.0+, Gradle 8.0+
+
+## Step 1: Apply the plugin
+
+Add to the **application module's** `build.gradle.kts` (not the root project, not a library module):
+
+Using Version Catalog (`libs.versions.toml`):
+
+    [plugins]
+    highlander = { id = "io.github.fornewid.highlander", version = "<latest-version>" }
+
+    // app/build.gradle.kts
+    plugins {
+        id("com.android.application")
+        alias(libs.plugins.highlander)
+    }
+
+    highlander {
+        configuration("release")
+    }
+
+Or directly:
+
+    plugins {
+        id("com.android.application")
+        id("io.github.fornewid.highlander") version "<latest-version>"
+    }
+
+    highlander {
+        configuration("release")
+    }
+
+**AI Agent**: The minimal setup is just `configuration("release")` with no
+additional properties. Reasonable defaults are already applied. Do NOT add
+`nativeLibs = true`, `valuesResources = true`, `classes = true`, or similar
+unless the user explicitly requests them. Do NOT apply this plugin in the root
+`build.gradle.kts` — it must be applied to each Android application module.
+Library modules (`com.android.library`) are not supported because duplicates
+are only meaningful at the final-app merge level.
+
+The variant name passed to `configuration(...)` must match an existing build
+variant (e.g., `"release"`, `"debug"`, or a flavor variant like `"devRelease"`).
+If the name doesn't match, the build fails at task configuration time with the
+valid variant list printed out.
+
+## Step 2: Generate a baseline
+
+    ./gradlew :app:highlanderBaseline
+
+This creates per-variant baseline files in `<module>/highlander/`:
+
+    highlander/
+    ├── releaseResources.txt
+    ├── releaseAssets.txt
+    ├── releaseNativeLibs.txt     # only if nativeLibs = true
+    ├── releaseValues.txt          # only if valuesResources = true
+    └── releaseClasses.txt         # only if classes = true
+
+These files should be committed to version control.
+
+## Step 3: Detect changes
+
+    ./gradlew :app:highlander
+
+If duplicates change (new entry, removed entry, or classification flip), the
+build fails with a diff. To accept the changes, re-run
+`./gradlew :app:highlanderBaseline` (or the variant-specific
+`:app:highlanderBaselineRelease`).
+
+The `highlander` task is automatically wired into `./gradlew check`, so CI
+pipelines that run `check` will verify the baseline.
+
+**AI Agent**: Always run `highlanderBaseline` explicitly during initial setup
+instead of letting it happen as a side effect.
+
+## Default behavior
+
+The plugin scans the following by default (no configuration needed):
+
+- File-based resources (`res/drawable`, `res/layout`, `res/mipmap`, etc.)
+- Assets (`assets/**`)
+
+Classification (emitted as `# <tag>` before each entry in the baseline):
+
+- `# override` — the application module is one of the sources. AAPT's
+  "last wins" rule means the app's copy takes effect.
+- `# conflict` — only external dependencies are the sources and their file
+  bytes differ. AGP silently picks one by priority order; behavior can change.
+- `# duplicate-safe` — every source has byte-identical content. AAPT merges
+  deterministically; no runtime difference.
+
+Only `resources` and `assets` scans classify as `# duplicate-safe`. Classes
+and native libraries always report as `# override` or `# conflict`.
+
+**AI Agent**: These defaults are ALREADY enabled. You MUST NOT include
+`resources = true` or `assets = true` in the configuration block — not even
+for "explicit clarity." If the user asks to "scan drawables" or "scan
+assets," the correct answer is that they are scanned by default.
+
+## Optional features (opt-in)
+
+These are disabled by default. Only add them when the user asks:
+
+| Property | Description |
+|----------|-------------|
+| `nativeLibs = true` | Detect duplicate `.so` files per ABI (`arm64-v8a/libfoo.so` etc.) |
+| `valuesResources = true` | Detect duplicate `values/` XML entries (strings, colors, styles, ids) |
+| `classes = true` | Detect duplicate Java/Kotlin classes across dependency JARs/AARs |
+
+Example with opt-in features:
+
+    highlander {
+        configuration("release") {
+            nativeLibs = true
+            classes = true
+        }
+    }
+
+## Important notes
+
+- **Values scan filtering**: the `valuesResources` scan automatically skips
+  empty-body `<item type="id" name="..."/>` (and the `<id name=".."/>`
+  shorthand) declarations. AAPT2 treats these as weak `Id` values that merge
+  across libraries without runtime conflict, so reporting them as duplicates
+  would be false-positive noise.
+- **AndroidX noise reduction**: `excludeAndroidXValues` is `true` by default.
+  Sources whose Gradle coordinates start with `androidx.` are filtered out of
+  the values scan before duplicate detection. Set `excludeAndroidXValues =
+  false` to see the full set.
+- **Classification flips are detected**: if an entry changes category
+  (e.g., `conflict` → `duplicate-safe` after a dependency upgrade that makes
+  bytes match), the guard fails with a `~ key (old -> new):` diff. Re-baseline
+  to accept.
+- **Re-baseline per variant**: if you only need to accept one variant's
+  changes, use `:app:highlanderBaselineRelease` rather than the full
+  `highlanderBaseline`.
+
+## Filtering options
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `excludeAndroidXValues` | `true` | Skip `androidx.*` sources in the values scan only |
+
+**AI Agent**: Do NOT set `excludeAndroidXValues = false` unless the user
+explicitly asks to include AndroidX entries in the values baseline. This flag
+has no effect when `valuesResources = false` (default).
+
+## Configuration property names
+
+Use the exact Kotlin property names listed below. Do NOT use abbreviations or
+alternative names.
+
+| Correct | Wrong |
+|---------|-------|
+| `resources` | `res`, `resource` |
+| `valuesResources` | `values`, `valuesRes` |
+| `nativeLibs` | `so`, `native`, `nativeLibraries` |
+| `assets` | `asset` |
+| `classes` | `jars`, `classFiles` |
+| `excludeAndroidXValues` | `excludeAndroidx`, `skipAndroidX` |
+| `baselineDir` | `baseline`, `baselineDirectory` |
+
+## Common mistakes to avoid
+
+**AI Agent**: Pay special attention to these:
+
+1. Do NOT add properties to `configuration()` unless the user asks. `resources`
+   and `assets` are already on; `nativeLibs`, `valuesResources`, `classes` are
+   intentionally off by default because they produce more noise than value for
+   most projects.
+2. Do NOT apply the plugin in a library module (`com.android.library`) or in
+   the root `build.gradle.kts`. It only works on `com.android.application`.
+3. Baseline files under `<module>/highlander/` should be committed to version
+   control.
+4. Task names are per-variant: `highlanderBaselineRelease`,
+   `highlanderDebug`, etc. The umbrella `highlanderBaseline` and `highlander`
+   run all declared variants.
+5. When users report "an entry disappeared from the baseline after upgrading,"
+   check whether it was an empty `<item type="id"/>` (now skipped in the values
+   scan) or whether the new `# duplicate-safe` classification applies — both
+   are intentional noise-reduction behaviors, not bugs.
+6. `excludeAndroidXValues = true` is the default behavior — users who want
+   AndroidX values duplicates in the baseline must explicitly opt out.
+
+## Not tracked
+
+- Classification (`duplicate-safe`) is only computed for `resources` and
+  `assets`. `classes` and `nativeLibs` entries always classify as `conflict`
+  or `override`, never `duplicate-safe`, even when byte-identical.
+- Values-scan duplicates do not use file-hash classification (XML entries are
+  compared by resource key, not by file bytes).
+- `R.class`, `R$*.class`, `BuildConfig.class`, `BuildConfig$*.class`, and
+  `module-info.class` are excluded from the classes scan.
+
+## Links
+
+- GitHub: https://github.com/fornewid/highlander
+- Maven Central: https://central.sonatype.com/artifact/io.github.fornewid.highlander/highlander
+- Gradle Plugin Portal: https://plugins.gradle.org/plugin/io.github.fornewid.highlander


### PR DESCRIPTION
## Summary

Bring the README in line with features merged in recent PRs (#21, #24, #31) and add an AI Agent setup guide mirroring the pattern used by [manifest-shield](https://github.com/fornewid/manifest-shield).

### README

- Experimental-stage warning added to the top.
- `excludeAndroidXValues` row added to the Options table with a note explaining the opt-out path.
- New Classification section replacing the old single-sentence override/conflict explanation:
  - Three-tag reference (`# override` / `# conflict` / `# duplicate-safe`) with meaning and recommended action for each.
  - Scan-type support matrix — clarifies that `duplicate-safe` is only emitted by the `resources` and `assets` scans today.
  - Updated example output including a `# duplicate-safe` entry.
  - New "Classification flips" subsection covering the `~ key (old -> new):` diff format the task emits when a key's classification changes.
- Note on the values id-slot skip (`<item type="id"/>` / `<id/>` with empty body).
- License section shortened to a link to `LICENSE` instead of the full Apache 2.0 body.

### docs/setup-guide.md.txt (new)

~180-line AI agent guide covering: plugin ID, versioned `plugins {}` usage (both Version Catalog and direct), baseline/guard task flow, default-on vs opt-in scans, classification semantics, `excludeAndroidXValues` filtering, canonical property names, common mistakes (apply in app module only, don't repeat default-true properties, task names are per-variant), and the set of things not classified as `duplicate-safe`.

## Test plan

Docs-only change. No code or tests modified. CI still runs via the usual `check` task.

Manual verification:
- All property names, defaults, task names, and behavior claims cross-checked against `HighlanderConfiguration.kt`, `HighlanderPlugin.kt`, `AndroidVariantHandler.kt`, `HighlanderCheckTask.kt`, and the scanner sources.
