### PR TITLE
Add info-level diagnostic for excludeAndroidXValues filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ highlander {
 | `excludeAndroidXValues` | **`true`** | Filter out `androidx.*` sources from the values scan only |
 | `baselineDir` | `"highlander"` | Directory for baseline files |
 
-**Note on `excludeAndroidXValues`**: AndroidX components (Compose, Core, etc.) routinely share benign values declarations by design. Filtering them out keeps the values baseline signal-to-noise high. Set to `false` to include AndroidX entries. No effect unless `valuesResources = true`.
+**Note on `excludeAndroidXValues`**: AndroidX components (Compose, Core, etc.) routinely share benign values declarations by design. Filtering them out keeps the values baseline signal-to-noise high. Set to `false` to include AndroidX entries. No effect unless `valuesResources = true`. Run with `--info` to see how many AndroidX sources were excluded and how many unknown-origin sources remain (unknown-origin sources such as `files()` or some composite-build setups are not matched by the filter).
 
 **Note on values id-slot skip**: the values scan automatically skips empty-body `<item type="id" name="..."/>` (and the shorthand `<id name="..."/>`) declarations. AAPT2 treats these as weak `Id` values that merge across libraries without runtime conflict, so reporting them would be false-positive noise.
 

--- a/docs/setup-guide.md.txt
+++ b/docs/setup-guide.md.txt
@@ -140,7 +140,11 @@ Example with opt-in features:
 - **AndroidX noise reduction**: `excludeAndroidXValues` is `true` by default.
   Sources whose Gradle coordinates start with `androidx.` are filtered out of
   the values scan before duplicate detection. Set `excludeAndroidXValues =
-  false` to see the full set.
+  false` to see the full set. Run with `--info` to print how many AndroidX
+  sources were excluded and how many unknown-origin sources remain — unknown
+  origins (e.g. `files()` dependencies, some composite-build substitutions)
+  are not matched by the filter and require `excludeAndroidXValues = false`
+  for visibility.
 - **Classification flips are detected**: if an entry changes category
   (e.g., `conflict` → `duplicate-safe` after a dependency upgrade that makes
   bytes match), the guard fails with a `~ key (old -> new):` diff. Re-baseline

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
@@ -96,6 +96,16 @@ internal class HighlanderPluginTest {
     }
 
     @Test
+    fun `values scan emits diagnostic info log when excludeAndroidXValues is true`() {
+        AndroidXValuesProject(excludeAndroidXValues = true).use { project ->
+            val result = Builder.build(project.dir, ":app:highlanderBaselineRelease", "--info")
+
+            assertThat(result.output).contains("Highlander values scan")
+            assertThat(result.output).contains("excluded 1 androidx source")
+        }
+    }
+
+    @Test
     fun `excludeAndroidXValues false keeps androidx values duplicates in baseline`() {
         AndroidXValuesProject(excludeAndroidXValues = false).use { project ->
             Builder.build(project.dir, ":app:highlanderBaselineRelease")

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
@@ -250,7 +250,17 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
         sources.addAll(resolveFromMapping(resArtifactMapping))
         addLocalDirs(sources, localResourceDirs)
         if (excludeAndroidXValues.get()) {
+            val excluded = sources.count { (_, origin) -> isAndroidXDependency(origin) }
             sources.removeAll { (_, origin) -> isAndroidXDependency(origin) }
+            val unknownKept = sources.count { (_, origin) -> origin is SourceOrigin.Unknown }
+            logger.info(
+                "Highlander values scan ({}): excluded {} androidx source(s), kept {} source(s) ({} unknown-origin). " +
+                    "Unknown-origin sources (files(), some composite builds) are not matched by the androidx filter.",
+                configurationName.get(),
+                excluded,
+                sources.size,
+                unknownKept,
+            )
         }
         return ValuesResourceScanner.scan(sources)
     }


### PR DESCRIPTION
## Summary

Gives users a way to see how the `excludeAndroidXValues` filter behaved. When the flag is on, `HighlanderCheckTask.scanValues()` now logs, at info level:

- how many sources were excluded because their coordinates start with `androidx.`,
- how many sources remain, and
- how many of those remaining sources are `Unknown`-origin (e.g. `files()` dependencies, some composite-build setups), which the androidx prefix filter cannot match.

Surfaces the edge case raised in #25 — previously there was no way for a user to notice that a filter gap existed without diffing against `excludeAndroidXValues = false`.

Refs #25

## Test plan

- [x] `:highlander:test`
- [x] `:highlander:gradleTest` (includes a new `values scan emits diagnostic info log when excludeAndroidXValues is true` case that runs with `--info` and asserts on the log output)

## Docs

- README note on `excludeAndroidXValues` mentions running with `--info` to see the diagnostic.
- `docs/setup-guide.md.txt` mirrors the same note under "Important notes".
