### PR TITLE
Cover flavored variants in gradleTest

### DIFF
--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
@@ -67,6 +67,52 @@ internal class HighlanderPluginTest {
     }
 
     @Test
+    fun `baseline task works with flavored variant`() {
+        val pluginConfig = """
+            highlander {
+                configuration("devRelease")
+            }
+        """.trimIndent()
+
+        AndroidProject(
+            pluginConfig = pluginConfig,
+            appResources = mapOf("drawable/ic_shared.xml" to "<vector/>"),
+            moduleResources = mapOf("drawable/ic_shared.xml" to "<vector/>"),
+            flavors = listOf("dev", "prod"),
+        ).use { project ->
+            build(project, ":app:highlanderBaselineDevRelease")
+
+            val baseline = project.readFile("app/highlander/devReleaseResources.txt")
+            assertThat(baseline).isNotNull()
+            assertThat(baseline).contains("drawable/ic_shared")
+            assertThat(baseline).contains(":app")
+            assertThat(baseline).contains(":module1")
+        }
+    }
+
+    @Test
+    fun `unmatched configuration error lists flavored variants`() {
+        val pluginConfig = """
+            highlander {
+                configuration("nonExistent")
+            }
+        """.trimIndent()
+
+        AndroidProject(
+            pluginConfig = pluginConfig,
+            flavors = listOf("dev", "prod"),
+        ).use { project ->
+            val result = buildAndFail(project, ":app:highlander")
+
+            assertThat(result.output).contains("could not resolve configuration \"nonExistent\"")
+            assertThat(result.output).contains("configuration(\"devRelease\")")
+            assertThat(result.output).contains("configuration(\"devDebug\")")
+            assertThat(result.output).contains("configuration(\"prodRelease\")")
+            assertThat(result.output).contains("configuration(\"prodDebug\")")
+        }
+    }
+
+    @Test
     fun `unmatched configuration fails with available variants`() {
         val pluginConfig = """
             highlander {

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidProject.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/fixture/AndroidProject.kt
@@ -6,6 +6,11 @@ internal class AndroidProject(
     private val pluginConfig: String = DEFAULT_PLUGIN_CONFIG,
     private val appResources: Map<String, String> = emptyMap(),
     private val moduleResources: Map<String, String> = emptyMap(),
+    /**
+     * Flavor names to declare under a single `env` dimension on the app module.
+     * Empty disables the flavor block and preserves single build-type variants.
+     */
+    private val flavors: List<String> = emptyList(),
 ) : AutoCloseable {
 
     private val scaffold: TestProjectScaffold = TestProjectScaffold.create()
@@ -17,6 +22,15 @@ internal class AndroidProject(
         scaffold.writeRootBuildscript()
         scaffold.writeGradleProperties()
         scaffold.writeLocalProperties()
+
+        val flavorsBlock = if (flavors.isEmpty()) "" else buildString {
+            append("flavorDimensions \"env\"\n")
+            append("    productFlavors {\n")
+            for (flavor in flavors) {
+                append("        $flavor { dimension \"env\" }\n")
+            }
+            append("    }")
+        }
 
         // app module
         val appDir = dir.resolve("app").apply { mkdirs() }
@@ -32,6 +46,7 @@ internal class AndroidProject(
                     minSdk 23
                     targetSdk 34
                 }
+                $flavorsBlock
             }
 
             dependencies {


### PR DESCRIPTION
## Summary

Covers the flavored-variant code path in gradleTest. Until now only the plain `release` / `debug` variants were exercised, so compound names like `devRelease` had no regression coverage — the CC-safe variant matching added in PR #17 and the error message emitted by `validateConfigurations` were both untested against the multi-variant shape.

Extends `AndroidProject` with a `flavors: List<String>` parameter that emits a single-dimension `flavorDimensions` / `productFlavors` block in the app module. Existing fixtures keep their current shape via the empty-list default — no existing test was changed.

Adds two gradleTest cases:

- `baseline task works with flavored variant` — `flavors = ["dev", "prod"]`, `configuration("devRelease")`, verifies `:app:highlanderBaselineDevRelease` produces `app/highlander/devReleaseResources.txt` with both app and module sources.
- `unmatched configuration error lists flavored variants` — bad variant name triggers the guard error; assertion confirms the suggestion list contains all four of `devRelease`, `devDebug`, `prodRelease`, `prodDebug`.

Closes #16

## Test plan

- [x] `:highlander:gradleTest` (two new cases pass; all prior cases remain green)
- [x] `:highlander:test`
