### PR TITLE
Use environment: release in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,20 +19,9 @@ permissions:
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
-    # TODO: Replace permission check with `environment: release` after making repo public.
-    # environment: release
+    environment: release
     steps:
       - uses: actions/checkout@v6
-
-      - name: Check admin permission
-        run: |
-          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
-          if [[ "$PERMISSION" != "admin" ]]; then
-            echo "::error::Only repository admins can create releases. Your permission: $PERMISSION"
-            exit 1
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine release version
         id: version


### PR DESCRIPTION
## Summary

The repository is now public, so GitHub Environments protection is available on the free tier. Replace the interim admin-permission check in the release workflow with `environment: release`, matching the pattern used by [manifest-shield](https://github.com/fornewid/manifest-shield).

Access control for manually running the release workflow now flows through the Environment's configured reviewers / deployment-branch rules instead of a script that reads `repos/{owner}/{repo}/collaborators/{actor}/permission`.

## Action required before the next release

Create the `release` Environment on GitHub (`Settings → Environments → New environment → release`) with the desired protection rules — typically "Required reviewers" and "Deployment branches: main only". Without the Environment, a manual run of this workflow will fail with "environment not found" while leaving CI/publish unaffected.

## Scope

Touches only `.github/workflows/release.yml`. Other workflows unchanged.
