### PR TITLE
Add skipContentIdenticalDuplicates flag (default on) for compact baselines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,10 @@ This is a Gradle plugin (`io.github.fornewid.highlander`) that detects duplicate
 
 `HighlanderConfiguration` defaults:
 
-- **`true`**: `resources`, `assets`, `excludeAndroidXValues`
+- **`true`**: `resources`, `assets`, `excludeAndroidXValues`, `skipContentIdenticalDuplicates`
 - **`false`** (opt-in, noisier): `nativeLibs`, `valuesResources`, `classes`
+
+`skipContentIdenticalDuplicates = true` means `HighlanderCheckTask.processBaseline` drops entries classified as `DUPLICATE_SAFE` before serializing / comparing. The baseline therefore only contains `# override` and `# conflict` entries by default. Set the flag to `false` in tests that need to assert on `# duplicate-safe` output.
 
 ### Test Structure
 

--- a/README.md
+++ b/README.md
@@ -77,12 +77,13 @@ highlander {
     baselineDir.set("highlander") // default
 
     configuration("release") {
-        resources = true               // Scan res/ file-based resources
-        assets = true                  // Scan assets/
-        nativeLibs = false             // Scan .so native libraries
-        valuesResources = false        // Scan values/ XML entries (strings, colors, etc.)
-        classes = false                // Scan Java/Kotlin classes in JARs/AARs
-        excludeAndroidXValues = true   // Drop androidx.* sources from the values scan
+        resources = true                        // Scan res/ file-based resources
+        assets = true                           // Scan assets/
+        nativeLibs = false                      // Scan .so native libraries
+        valuesResources = false                 // Scan values/ XML entries (strings, colors, etc.)
+        classes = false                         // Scan Java/Kotlin classes in JARs/AARs
+        excludeAndroidXValues = true            // Drop androidx.* sources from the values scan
+        skipContentIdenticalDuplicates = true   // Drop byte-identical duplicates from the baseline
     }
 }
 ```
@@ -97,11 +98,14 @@ highlander {
 | `valuesResources` | `false` | Detect duplicate values entries (`string`, `color`, `dimen`, etc.) |
 | `classes` | `false` | Detect duplicate Java/Kotlin classes across dependency JARs/AARs |
 | `excludeAndroidXValues` | **`true`** | Filter out `androidx.*` sources from the values scan only |
+| `skipContentIdenticalDuplicates` | **`true`** | Omit byte-identical duplicates (classified `duplicate-safe`) from the baseline |
 | `baselineDir` | `"highlander"` | Directory for baseline files |
 
 **Note on `excludeAndroidXValues`**: AndroidX components (Compose, Core, etc.) routinely share benign values declarations by design. Filtering them out keeps the values baseline signal-to-noise high. Set to `false` to include AndroidX entries. No effect unless `valuesResources = true`. Run with `--info` to see how many AndroidX sources were excluded and how many unknown-origin sources remain (unknown-origin sources such as `files()` or some composite-build setups are not matched by the filter).
 
 **Note on values id-slot skip**: the values scan automatically skips empty-body `<item type="id" name="..."/>` (and the shorthand `<id name="..."/>`) declarations. AAPT2 treats these as weak `Id` values that merge across libraries without runtime conflict, so reporting them would be false-positive noise.
+
+**Note on `skipContentIdenticalDuplicates`**: enabled by default to keep the baseline compact — only entries that need review (`# override`, `# conflict`) are persisted. Divergent-content conflicts that used to be byte-identical still surface the moment they diverge (the new `# conflict` entry appears in the diff). Set to `false` to retain `# duplicate-safe` lines in the baseline if you want a historical record of benign duplicates. Only affects scans that classify as `duplicate-safe` today (`resources`, `assets`).
 
 ## Baseline Files
 

--- a/docs/setup-guide.md.txt
+++ b/docs/setup-guide.md.txt
@@ -137,6 +137,14 @@ Example with opt-in features:
   shorthand) declarations. AAPT2 treats these as weak `Id` values that merge
   across libraries without runtime conflict, so reporting them as duplicates
   would be false-positive noise.
+- **Compact baseline by default**: `skipContentIdenticalDuplicates` is `true` by
+  default. Entries classified as `duplicate-safe` (every source has the same
+  file bytes) are omitted from the baseline so it only contains actionable
+  entries. Set to `false` if you want a historical record of byte-identical
+  duplicates in the file. Only affects scans that emit `duplicate-safe`
+  (resource and asset). Drift where two libraries used to match but no longer
+  do is still surfaced either way — the post-change entry shows up as a new
+  `# conflict`.
 - **AndroidX noise reduction**: `excludeAndroidXValues` is `true` by default.
   Sources whose Gradle coordinates start with `androidx.` are filtered out of
   the values scan before duplicate detection. Set `excludeAndroidXValues =
@@ -158,6 +166,7 @@ Example with opt-in features:
 | Property | Default | Description |
 |----------|---------|-------------|
 | `excludeAndroidXValues` | `true` | Skip `androidx.*` sources in the values scan only |
+| `skipContentIdenticalDuplicates` | `true` | Omit `duplicate-safe` entries (byte-identical duplicates) from the baseline |
 
 **AI Agent**: Do NOT set `excludeAndroidXValues = false` unless the user
 explicitly asks to include AndroidX entries in the values baseline. This flag
@@ -176,6 +185,7 @@ alternative names.
 | `assets` | `asset` |
 | `classes` | `jars`, `classFiles` |
 | `excludeAndroidXValues` | `excludeAndroidx`, `skipAndroidX` |
+| `skipContentIdenticalDuplicates` | `skipDuplicateSafe`, `hideDuplicateSafe` |
 | `baselineDir` | `baseline`, `baselineDirectory` |
 
 ## Common mistakes to avoid

--- a/highlander/api/highlander.api
+++ b/highlander/api/highlander.api
@@ -7,12 +7,14 @@ public class io/github/fornewid/gradle/plugins/highlander/HighlanderConfiguratio
 	public fun getName ()Ljava/lang/String;
 	public final fun getNativeLibs ()Z
 	public final fun getResources ()Z
+	public final fun getSkipContentIdenticalDuplicates ()Z
 	public final fun getValuesResources ()Z
 	public final fun setAssets (Z)V
 	public final fun setClasses (Z)V
 	public final fun setExcludeAndroidXValues (Z)V
 	public final fun setNativeLibs (Z)V
 	public final fun setResources (Z)V
+	public final fun setSkipContentIdenticalDuplicates (Z)V
 	public final fun setValuesResources (Z)V
 }
 

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
@@ -258,8 +258,6 @@ internal class HighlanderPluginTest {
         val pluginConfig = """
             highlander {
                 configuration("release") {
-                    resources = true
-                    nativeLibs = false
                     assets = false
                     skipContentIdenticalDuplicates = false
                 }
@@ -300,8 +298,6 @@ internal class HighlanderPluginTest {
         val pluginConfig = """
             highlander {
                 configuration("release") {
-                    resources = true
-                    nativeLibs = false
                     assets = false
                     skipContentIdenticalDuplicates = false
                 }

--- a/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
+++ b/highlander/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderPluginTest.kt
@@ -12,9 +12,11 @@ internal class HighlanderPluginTest {
 
     @Test
     fun `baseline task creates baseline file`() {
+        // Divergent content so the duplicate is recorded (not dropped by the default
+        // skipContentIdenticalDuplicates = true).
         AndroidProject(
             appResources = mapOf("drawable/ic_shared.xml" to "<vector/>"),
-            moduleResources = mapOf("drawable/ic_shared.xml" to "<vector/>"),
+            moduleResources = mapOf("drawable/ic_shared.xml" to "<shape/>"),
         ).use { project ->
             build(project, ":app:highlanderBaselineRelease")
 
@@ -30,7 +32,7 @@ internal class HighlanderPluginTest {
     fun `guard task passes when baseline matches`() {
         AndroidProject(
             appResources = mapOf("drawable/ic_shared.xml" to "<vector/>"),
-            moduleResources = mapOf("drawable/ic_shared.xml" to "<vector/>"),
+            moduleResources = mapOf("drawable/ic_shared.xml" to "<shape/>"),
         ).use { project ->
             build(project, ":app:highlanderBaselineRelease")
             // Should succeed without error
@@ -42,10 +44,11 @@ internal class HighlanderPluginTest {
     fun `guard task fails when new duplicate appears`() {
         AndroidProject(
             appResources = mapOf("drawable/ic_app.xml" to "<vector/>"),
-            moduleResources = mapOf("drawable/ic_module.xml" to "<vector/>"),
+            moduleResources = mapOf("drawable/ic_module.xml" to "<shape/>"),
         ).use { project ->
             build(project, ":app:highlanderBaselineRelease")
 
+            // Add a divergent-content duplicate so it is not dropped as duplicate-safe.
             project.addAppResource("drawable/ic_module.xml", "<vector/>")
 
             val result = buildAndFail(project, ":app:highlanderRelease")
@@ -76,8 +79,10 @@ internal class HighlanderPluginTest {
 
         AndroidProject(
             pluginConfig = pluginConfig,
+            // Divergent content so the duplicate survives the default
+            // skipContentIdenticalDuplicates = true filter.
             appResources = mapOf("drawable/ic_shared.xml" to "<vector/>"),
-            moduleResources = mapOf("drawable/ic_shared.xml" to "<vector/>"),
+            moduleResources = mapOf("drawable/ic_shared.xml" to "<shape/>"),
             flavors = listOf("dev", "prod"),
         ).use { project ->
             build(project, ":app:highlanderBaselineDevRelease")
@@ -225,24 +230,52 @@ internal class HighlanderPluginTest {
     }
 
     @Test
-    fun `baseline emits duplicate-safe for byte-identical resources from external deps`() {
-        // Two dependencies with identical-byte resources → classified as duplicate-safe.
-        // We use Unknown-origin sources (from files()-style local AAR) to avoid the
-        // app-module override promotion path.
+    fun `skipContentIdenticalDuplicates default drops duplicate-safe entries from baseline`() {
         AndroidProject(
-            appResources = mapOf("drawable/ic_app_only.xml" to "<app/>"),
-            moduleResources = mapOf("drawable/ic_same.xml" to "<vector/>"),
+            appResources = mapOf(
+                "drawable/ic_safe.xml" to "<vector/>",
+                "drawable/ic_conflict.xml" to "<vector/>",
+            ),
+            moduleResources = mapOf(
+                "drawable/ic_safe.xml" to "<vector/>",
+                "drawable/ic_conflict.xml" to "<shape/>",
+            ),
         ).use { project ->
-            // Add a second source with identical byte content in :module1 and :app.
-            project.addAppResource("drawable/ic_same.xml", "<vector/>")
-
             build(project, ":app:highlanderBaselineRelease")
 
             val baseline = project.readFile("app/highlander/releaseResources.txt")!!
-            // App module is one source of the byte-identical duplicate, but
-            // duplicate-safe is not promoted to override.
+            // Divergent content → CONFLICT promoted to OVERRIDE (app in sources).
+            assertThat(baseline).contains("# override")
+            assertThat(baseline).contains("drawable/ic_conflict")
+            // Byte-identical duplicate is filtered out by default.
+            assertThat(baseline).doesNotContain("# duplicate-safe")
+            assertThat(baseline).doesNotContain("drawable/ic_safe")
+        }
+    }
+
+    @Test
+    fun `skipContentIdenticalDuplicates false retains duplicate-safe entries`() {
+        val pluginConfig = """
+            highlander {
+                configuration("release") {
+                    resources = true
+                    nativeLibs = false
+                    assets = false
+                    skipContentIdenticalDuplicates = false
+                }
+            }
+        """.trimIndent()
+
+        AndroidProject(
+            pluginConfig = pluginConfig,
+            appResources = mapOf("drawable/ic_safe.xml" to "<vector/>"),
+            moduleResources = mapOf("drawable/ic_safe.xml" to "<vector/>"),
+        ).use { project ->
+            build(project, ":app:highlanderBaselineRelease")
+
+            val baseline = project.readFile("app/highlander/releaseResources.txt")!!
             assertThat(baseline).contains("# duplicate-safe")
-            assertThat(baseline).contains("drawable/ic_same")
+            assertThat(baseline).contains("drawable/ic_safe")
         }
     }
 
@@ -262,7 +295,21 @@ internal class HighlanderPluginTest {
 
     @Test
     fun `guard fails with classification flip diff when conflict becomes duplicate-safe`() {
+        // Opt out of the default so duplicate-safe entries stay in the baseline and
+        // the flip can surface as `override -> duplicate-safe` instead of a bare removal.
+        val pluginConfig = """
+            highlander {
+                configuration("release") {
+                    resources = true
+                    nativeLibs = false
+                    assets = false
+                    skipContentIdenticalDuplicates = false
+                }
+            }
+        """.trimIndent()
+
         AndroidProject(
+            pluginConfig = pluginConfig,
             appResources = mapOf("drawable/ic_same.xml" to "<vector/>"),
             moduleResources = mapOf("drawable/ic_same.xml" to "<shape/>"),
         ).use { project ->

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderConfiguration.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/HighlanderConfiguration.kt
@@ -45,4 +45,22 @@ public open class HighlanderConfiguration @Inject constructor(
 
     /** Scan for duplicate Java/Kotlin classes across dependency JARs/AARs */
     public var classes: Boolean = false
+
+    /**
+     * Skip byte-identical duplicates from the baseline entirely. Enabled by default.
+     *
+     * When true, entries classified as `DUPLICATE_SAFE` by the resource and asset scans
+     * (every source carries the same file bytes, so AAPT merges deterministically) are
+     * omitted from the baseline file. The result is a compact baseline that contains
+     * only entries that require review — app overrides and real conflicts.
+     *
+     * Set to `false` to retain `# duplicate-safe` entries in the baseline. This keeps a
+     * historical record of byte-identical duplicates so they can be inspected alongside
+     * real conflicts; drift where two libraries used to match but no longer do is still
+     * surfaced either way (the post-change entry appears as a new `# conflict`).
+     *
+     * Only the resource and asset scans emit `DUPLICATE_SAFE`, so the flag has no effect
+     * on native-libs, values, or classes scans.
+     */
+    public var skipContentIdenticalDuplicates: Boolean = true
 }

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/AndroidVariantHandler.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/AndroidVariantHandler.kt
@@ -153,6 +153,7 @@ internal object AndroidVariantHandler {
             task.scanAssets.set(config.assets)
             task.scanClasses.set(config.classes)
             task.excludeAndroidXValues.set(config.excludeAndroidXValues)
+            task.skipContentIdenticalDuplicates.set(config.skipContentIdenticalDuplicates)
             task.baselineDir.set(baselineDirectory)
             task.projectDir.set(project.layout.projectDirectory)
 

--- a/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
+++ b/highlander/src/main/kotlin/io/github/fornewid/gradle/plugins/highlander/internal/task/HighlanderCheckTask.kt
@@ -44,6 +44,7 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
     @get:Input abstract val scanAssets: Property<Boolean>
     @get:Input abstract val scanClasses: Property<Boolean>
     @get:Input abstract val excludeAndroidXValues: Property<Boolean>
+    @get:Input abstract val skipContentIdenticalDuplicates: Property<Boolean>
 
     @get:Internal abstract val baselineDir: DirectoryProperty
     @get:Internal abstract val projectDir: DirectoryProperty
@@ -157,7 +158,12 @@ internal abstract class HighlanderCheckTask : DefaultTask() {
         current: List<DuplicateEntry>,
         isBaseline: Boolean,
     ): String? {
-        val promoted = current.map { promoteAppOverride(it) }
+        val filtered = if (skipContentIdenticalDuplicates.get()) {
+            current.filter { it.classification != Classification.DUPLICATE_SAFE }
+        } else {
+            current
+        }
+        val promoted = filtered.map { promoteAppOverride(it) }
         val currentContent = BaselineFormat.serialize(promoted)
 
         if (isBaseline) {


### PR DESCRIPTION
## Summary

Adds an opt-out flag for retaining `# duplicate-safe` entries in the baseline. Default is `true` — byte-identical duplicates are dropped from the file so only reviewable entries (`# override`, `# conflict`) remain.

Motivation from #39: PR #31 made the `# conflict` label trustworthy, but the baseline file length did not shrink — in the media3 + exoplayer-ui reproducer 241 of 244 entries simply switched tag. Keeping those lines defeats the point of the baseline. Matches the "compact by default" pattern already established by `excludeAndroidXValues = true` and the values id-slot skip.

### Behavior

- `HighlanderCheckTask.processBaseline` filters `current` entries where `classification == DUPLICATE_SAFE` before override promotion and serialization.
- Scanners still compute byte-hash classification (cost is bounded by duplicate count), so toggling the flag only affects output — not scan semantics.
- Drift detection is preserved both ways: a previously-identical duplicate that diverges later appears as a new `# conflict` on the next guard run.

### API

New public property on `HighlanderConfiguration`:
```kotlin
public var skipContentIdenticalDuplicates: Boolean = true
```
`highlander/api/highlander.api` regenerated.

Closes #39

## Migration

Existing 0.0.4 baselines that persist `# duplicate-safe` entries will diff against scanner output on the first guard run after upgrade — those entries disappear from `current` so the guard reports them as removed. Re-baseline once:
```
./gradlew :<project>:highlanderBaseline<Variant>
```

Users who want to keep historical `# duplicate-safe` records in the file can set `skipContentIdenticalDuplicates = false`.

## Test plan

- [x] `:highlander:test`
- [x] `:highlander:gradleTest` (default-on filter, explicit false retention; prior tests updated to use divergent content where they relied on the old default)
- [x] `:highlander:apiCheck`
- [x] `:sample:app:highlanderBaselineRelease --configuration-cache` — sample baseline unchanged (`# override drawable/ic_close` kept since sample sources have divergent content)
