### PR TITLE
ci: GitHub Actions Node 24 호환 버전 업데이트

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'fornewid/highlander'
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7.3.1
         with:
           publish: ${{ startsWith(github.ref, 'refs/tags/') }}
         env:


### PR DESCRIPTION
Node 20 deprecation(2026-06-02 Node 24 강제) 대응. checkout/setup-* 등 버전 상향.